### PR TITLE
feat(onboarding): showcase → post-onboarding personalized value bridge

### DIFF
--- a/src/features/onboarding/config/app-showcase.ts
+++ b/src/features/onboarding/config/app-showcase.ts
@@ -1,13 +1,17 @@
 import type { ShowcaseConfig } from "wireai-onboarding/showcase";
 
 /**
- * app-showcase.ts — the pre-onboarding "app intro" slides.
+ * app-showcase.ts — the "app intro" slide catalog.
  *
- * A small, declarative `ShowcaseConfig` shown ONCE before the Wire AI onboarding
- * starts (see `wire-onboarding-screen.tsx`). The kit maps this onto the
- * `@blazejkustra/react-native-onboarding` package, bakes in the onboarding theme
- * colors, and gates it once through the shared coachmark storage
+ * A small, declarative `ShowcaseConfig` shown as a personalized value bridge AFTER
+ * the Wire AI onboarding completes (see `wire-onboarding-screen.tsx`, which selects
+ * 2-3 of these from the answers via `select-showcase-slides.ts`). The kit maps this
+ * onto the `@blazejkustra/react-native-onboarding` package, bakes in the onboarding
+ * theme colors, and gates it once through the shared coachmark storage
  * (`wire_showcase_<id>_seen`). Swap the copy + images for your own product story.
+ *
+ * No `gesture` props here — swipe/tap hints belong to the coachmark tour, delivered
+ * just-in-time when the user is on the screen, not to these intro stills.
  *
  * Images reuse the boilerplate's bundled brand assets so a fresh clone renders
  * something real with zero extra files — replace them with dedicated slide art.
@@ -26,7 +30,6 @@ export const APP_SHOWCASE: ShowcaseConfig = {
       description:
         "Personalized, backend-driven onboarding out of the box — with a static fallback.",
       image: require("../../../../assets/icon-light.png"),
-      gesture: "tap",
     },
     {
       id: "batteries_included",

--- a/src/features/onboarding/config/index.ts
+++ b/src/features/onboarding/config/index.ts
@@ -10,3 +10,8 @@ export {
   isLanguageSupported,
   Onboarding_Questionnaires,
 } from "./onboarding-questionnaires";
+export {
+  selectAppShowcaseSlideIds,
+  selectAppShowcaseSlides,
+  selectShowcaseSlides,
+} from "./select-showcase-slides";

--- a/src/features/onboarding/config/select-showcase-slides.test.ts
+++ b/src/features/onboarding/config/select-showcase-slides.test.ts
@@ -1,0 +1,59 @@
+import type { ShowcaseSlide } from "wireai-onboarding/showcase";
+import {
+  selectAppShowcaseSlideIds,
+  selectAppShowcaseSlides,
+  selectShowcaseSlides,
+} from "./select-showcase-slides";
+
+const deck: ShowcaseSlide[] = [
+  { id: "ai_onboarding", title: "a", description: "" },
+  { id: "batteries_included", title: "b", description: "" },
+  { id: "ship_faster", title: "c", description: "" },
+];
+
+describe("selectAppShowcaseSlideIds", () => {
+  it("returns undefined when no answer matches a slide signal (→ full deck)", () => {
+    expect(selectAppShowcaseSlideIds({ q1: "hello there" })).toBeUndefined();
+  });
+
+  it("returns undefined for empty answers (→ full deck)", () => {
+    expect(selectAppShowcaseSlideIds({})).toBeUndefined();
+  });
+
+  it("maps an answer to the slide it speaks to", () => {
+    expect(selectAppShowcaseSlideIds({ goal: "I want to ship an MVP fast" })).toEqual([
+      "ship_faster",
+    ]);
+  });
+
+  it("keeps rule (priority) order and caps at 3", () => {
+    const ids = selectAppShowcaseSlideIds({
+      a: "guide me to start",
+      b: "I need auth and payment features",
+      c: "so I can ship fast",
+    });
+    expect(ids).toEqual(["ai_onboarding", "batteries_included", "ship_faster"]);
+  });
+});
+
+describe("selectShowcaseSlides (inline mirror of the kit helper)", () => {
+  it("returns the catalog unchanged when selection is absent", () => {
+    expect(selectShowcaseSlides(deck)).toBe(deck);
+  });
+
+  it("filters + orders by the selection, skipping unknown and duplicate ids", () => {
+    const out = selectShowcaseSlides(deck, ["ship_faster", "nope", "ai_onboarding", "ship_faster"]);
+    expect(out.map((s) => s.id)).toEqual(["ship_faster", "ai_onboarding"]);
+  });
+});
+
+describe("selectAppShowcaseSlides", () => {
+  it("returns the full deck when answers are thin", () => {
+    expect(selectAppShowcaseSlides(deck, {})).toEqual(deck);
+  });
+
+  it("returns only the personalized subset when answers match", () => {
+    const out = selectAppShowcaseSlides(deck, { goal: "guide me through the start" });
+    expect(out.map((s) => s.id)).toEqual(["ai_onboarding"]);
+  });
+});

--- a/src/features/onboarding/config/select-showcase-slides.ts
+++ b/src/features/onboarding/config/select-showcase-slides.ts
@@ -1,0 +1,96 @@
+import type { ShowcaseSlide } from "wireai-onboarding/showcase";
+
+/**
+ * select-showcase-slides — turn the user's onboarding answers into the 2-3 showcase
+ * slides shown as a PERSONALIZED VALUE BRIDGE right after onboarding completes.
+ *
+ * ┌─ THE PATTERN (this is the part worth copying) ────────────────────────────────┐
+ * │ The user just told you what they want. The moment onboarding ends is the       │
+ * │ highest-intent moment in the whole app, so instead of a generic pre-onboarding │
+ * │ intro, show only the slides that answer what they asked for, most-relevant     │
+ * │ first: "you said you want X → here's how the app does X" (the Duolingo /        │
+ * │ Headspace pattern). Keep it to 2-3 slides — a value BRIDGE, not a second        │
+ * │ onboarding.                                                                     │
+ * └────────────────────────────────────────────────────────────────────────────────┘
+ *
+ * THIS FILE IS AN EXAMPLE. The mapping below is deliberately simple and matches the
+ * three demo slides in `app-showcase.ts`. To adapt it to YOUR app:
+ *   1. Replace the `if` signals with YOUR questionnaire's answer keys/values.
+ *   2. Replace the pushed ids with YOUR slide ids.
+ *   3. Order the rules by priority — the first ids pushed show first.
+ * Everything else (the full-deck default, the de-dupe, the cap) you can keep as-is.
+ *
+ * Answers arrive from the kit as `result.answers`, a `{ questionKey: value }` map
+ * where values are natural-language strings the AI captured. This example doesn't
+ * depend on any exact question key: it flattens every answer into one lowercase blob
+ * and matches on keywords, which is the most forgiving thing to ship in a template.
+ * A real app with a fixed questionnaire would usually switch on a known key instead
+ * (e.g. `if (answers.goal === "lose_weight") ids.push("tracking")`).
+ */
+export const selectAppShowcaseSlideIds = (
+  answers: Record<string, unknown>
+): string[] | undefined => {
+  // Everything the user said, lowercased, as one string to keyword-match against.
+  const said = Object.values(answers).join(" ").toLowerCase();
+
+  // Push ids in PRIORITY order — the first pushed is shown first.
+  const ids: string[] = [];
+
+  // "You want a fast, guided start" → lead with the AI-onboarding slide.
+  if (said.includes("onboard") || said.includes("guide") || said.includes("start")) {
+    ids.push("ai_onboarding");
+  }
+  // "You want a lot built for you already" → the batteries-included slide.
+  if (said.includes("auth") || said.includes("payment") || said.includes("feature")) {
+    ids.push("batteries_included");
+  }
+  // "You want to move fast / ship an MVP" → the ship-faster slide.
+  if (said.includes("fast") || said.includes("ship") || said.includes("mvp")) {
+    ids.push("ship_faster");
+  }
+
+  // Nothing matched → return undefined so the caller shows the FULL deck. This is the
+  // safe default whenever answers are thin, or you're on the no-AI / static fallback
+  // path where there are no answers to personalize from.
+  if (ids.length === 0) return undefined;
+
+  // De-dupe (preserving order) and cap at 3 — a bridge, not a re-onboarding.
+  return [...new Set(ids)].slice(0, 3);
+};
+
+/**
+ * Filter + order a slide catalog by a list of ids. Same contract as the kit's
+ * `selectTourSteps` / `selectShowcaseSlides`: no selection → catalog unchanged;
+ * with a selection → only the listed ids, in that order, unknown ids skipped and
+ * duplicates ignored.
+ *
+ * TODO: swap this for `selectShowcaseSlides` imported from `wireai-onboarding/showcase`
+ * on the next kit bump — the helper ships in the kit but the pinned 0.2.1 here doesn't
+ * export it yet, so we inline the identical body to teach the pattern today.
+ */
+export const selectShowcaseSlides = <T extends { id: string }>(
+  catalog: T[],
+  selection?: string[]
+): T[] => {
+  if (!selection) return catalog;
+
+  const byId = new Map(catalog.map((item) => [item.id, item]));
+  const seen = new Set<string>();
+  const ordered: T[] = [];
+  for (const id of selection) {
+    if (seen.has(id)) continue;
+    seen.add(id);
+    const item = byId.get(id);
+    if (item) ordered.push(item);
+  }
+  return ordered;
+};
+
+/**
+ * Convenience the screen actually calls: given the full showcase slides and the
+ * onboarding answers, return the personalized subset (full deck when answers are thin).
+ */
+export const selectAppShowcaseSlides = (
+  slides: ShowcaseSlide[],
+  answers: Record<string, unknown>
+): ShowcaseSlide[] => selectShowcaseSlides(slides, selectAppShowcaseSlideIds(answers));

--- a/src/features/onboarding/screens/wire-onboarding-screen.tsx
+++ b/src/features/onboarding/screens/wire-onboarding-screen.tsx
@@ -7,13 +7,14 @@ import {
   WireOnboarding,
   wireConfigFromEnv,
 } from "wireai-onboarding";
+import type { ShowcaseSlide } from "wireai-onboarding/showcase";
 import { FeatureShowcase } from "wireai-onboarding/showcase";
 import { analytics, EVENTS } from "#root/analytics";
 import { logger } from "#root/services/logging";
 import { useAppDispatch } from "#root/store/store";
 import { Box } from "#root/ui/components";
 import { useTheme } from "#root/ui/style/theme-provider";
-import { APP_SHOWCASE } from "../config";
+import { APP_SHOWCASE, selectAppShowcaseSlides } from "../config";
 import { wireOnboardingStorage } from "../services/wire-onboarding-storage";
 import { completeOnboarding } from "../store/onboarding-slice";
 import { OnboardingScreen as StaticOnboardingScreen } from "./onboarding-screen";
@@ -36,23 +37,30 @@ export const WireOnboardingScreen: React.FC = () => {
   const dispatch = useAppDispatch();
   const { theme } = useTheme();
 
-  // App-intro showcase (wireai-onboarding/showcase): 3 static slides shown ONCE
-  // before onboarding starts. The kit gates it via the shared coachmark storage
-  // (`wire_showcase_<id>_seen`) — if already seen it renders nothing and calls
-  // `onDone` from an effect, so this state simply advances to the flow below.
-  const [showcaseDone, setShowcaseDone] = useState(false);
-  const handleShowcaseDone = useCallback(() => setShowcaseDone(true), []);
+  // App-intro showcase (wireai-onboarding/showcase), rendered as a PERSONALIZED
+  // VALUE BRIDGE *after* onboarding completes: 2-3 slides picked from the user's
+  // answers (see `select-showcase-slides.ts`). `null` = onboarding not finished yet;
+  // a slide array = play the bridge, then enter the app. The kit still gates it once
+  // (`wire_showcase_<id>_seen`) — if already seen it calls `onDone` from an effect.
+  const [bridgeSlides, setBridgeSlides] = useState<ShowcaseSlide[] | null>(null);
 
-  const handleComplete = useCallback(
-    (_result: OnboardingResult) => {
-      analytics.track(EVENTS.ONB_COMPLETE);
-      dispatch(completeOnboarding());
-    },
-    [dispatch]
-  );
+  const handleComplete = useCallback((result: OnboardingResult) => {
+    analytics.track(EVENTS.ONB_COMPLETE);
+    // Personalize the value bridge from what the user just told us (full deck when
+    // the answers are too thin to match — see selectAppShowcaseSlides). We DON'T
+    // dispatch completeOnboarding yet: that leaves this screen, so we wait until the
+    // bridge is done (handleBridgeDone).
+    setBridgeSlides(selectAppShowcaseSlides(APP_SHOWCASE.slides, result.answers));
+  }, []);
+
+  // Value bridge finished (or was already seen) → now finish onboarding for real.
+  const handleBridgeDone = useCallback(() => {
+    dispatch(completeOnboarding());
+  }, [dispatch]);
 
   const handleSkip = useCallback(() => {
     analytics.track(EVENTS.ONB_ABANDONED);
+    // User bailed — no answers to personalize from, so skip the bridge and finish.
     dispatch(completeOnboarding());
   }, [dispatch]);
 
@@ -67,6 +75,18 @@ export const WireOnboardingScreen: React.FC = () => {
     logger.logEvent("wire_onboarding_event", { event_type: event.type });
   }, []);
 
+  // After onboarding completes we hold the personalized slides — play the value
+  // bridge, then enter the app. The kit gates it to run at most once.
+  if (bridgeSlides) {
+    return (
+      <FeatureShowcase
+        config={{ ...APP_SHOWCASE, slides: bridgeSlides }}
+        accentColor={theme.colors.primary}
+        onDone={handleBridgeDone}
+      />
+    );
+  }
+
   const config = isOnboardingEnabled() ? wireConfigFromEnv({ appId: _appId }) : null;
 
   // No key configured (or explicitly disabled) → render the static flow unchanged,
@@ -74,17 +94,6 @@ export const WireOnboardingScreen: React.FC = () => {
   // keyless fresh clone shows the static questionnaire only (README promise).
   if (!config) {
     return <StaticOnboardingScreen />;
-  }
-
-  // Show the app-intro slides first; the kit gates them to run at most once.
-  if (!showcaseDone) {
-    return (
-      <FeatureShowcase
-        config={APP_SHOWCASE}
-        accentColor={theme.colors.primary}
-        onDone={handleShowcaseDone}
-      />
-    );
   }
 
   return (


### PR DESCRIPTION
**Stacked on `development`** (the showcase landed there via merged PR #2).

## What
Move the `FeatureShowcase` from a generic PRE-onboarding intro to a **personalized value bridge rendered AFTER the Wire AI onboarding completes**, showing 2-3 slides selected from `result.answers`. Because this is the public template, the selection mapping is a **heavily-commented teaching example**.

## Changes
- **`wire-onboarding-screen.tsx`**: showcase moved to after `onComplete`. Sequence: `onComplete(result)` → select slides from answers → value-bridge showcase → `completeOnboarding()`. Completion now dispatches on **bridge done**. The no-key/static path is unchanged (no showcase, per the keyless-clone README promise); `onSkip` finishes without a bridge (no answers to personalize from).
- **New `select-showcase-slides.ts`**: a heavily-commented `selectAppShowcaseSlideIds(answers)` example (answers → slide ids, priority order, capped at 3, **full-deck default** on thin answers) that teaches template users the pattern + how to adapt it. Ships an inline `selectShowcaseSlides` mirror (pinned kit 0.2.1 doesn't export it yet) with a `TODO: swap to selectShowcaseSlides on next kit bump`.
- **Stripped the `gesture: "tap"` prop** from the showcase config (gesture hints belong to the coachmark tour, just-in-time); docstring reframed as the value-bridge catalog.
- Tests for the selection mapping.

## Verification
- `npx tsc --noEmit` → clean
- `npx jest` (full) → **63 passed / 7 suites**, exit 0
- `biome check` on changed files → clean

Pairs with wireai-onboarding PR #11 (the `selectShowcaseSlides` kit helper) and the Morrow host PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5YoC4RSL4XW4RG9V3iTTS