### PR TITLE
chore: bump wireai-onboarding 0.2.1 -> 0.5.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-native-worklets": "0.7.4",
     "react-redux": "^9.1.0",
     "redux-persist": "^6.0.0",
-    "wireai-onboarding": "0.2.1",
+    "wireai-onboarding": "0.5.0",
     "wireai-rn": "^0.2.4",
     "zod": "^3.22.4"
   },

--- a/src/features/onboarding/config/select-showcase-slides.ts
+++ b/src/features/onboarding/config/select-showcase-slides.ts
@@ -64,9 +64,14 @@ export const selectAppShowcaseSlideIds = (
  * with a selection → only the listed ids, in that order, unknown ids skipped and
  * duplicates ignored.
  *
- * TODO: swap this for `selectShowcaseSlides` imported from `wireai-onboarding/showcase`
- * on the next kit bump — the helper ships in the kit but the pinned 0.2.1 here doesn't
- * export it yet, so we inline the identical body to teach the pattern today.
+ * The kit DOES export an identical `selectShowcaseSlides` from `wireai-onboarding/showcase`
+ * (since 0.3.x). We keep this inline mirror on purpose: that subpath loads the native
+ * showcase stack (`@blazejkustra/react-native-onboarding` + `react-native-reanimated`) at
+ * module load, so importing the helper as a runtime value here would drag those into the
+ * node test env and break the unit tests. Inlining the tiny, pure body keeps this file
+ * import-light and test-safe while teaching the exact same contract. (If you'd rather use
+ * the kit helper, import it from `wireai-onboarding/showcase` and mock that subpath in the
+ * test, the same way `coachmarks.test.ts` mocks `wireai-onboarding/coachmarks`.)
  */
 export const selectShowcaseSlides = <T extends { id: string }>(
   catalog: T[],

--- a/yarn.lock
+++ b/yarn.lock
@@ -6826,10 +6826,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wireai-onboarding@0.2.1:
-  version "0.2.1"
-  resolved "https://registry.yarnpkg.com/wireai-onboarding/-/wireai-onboarding-0.2.1.tgz#e19dcc1b327176ff295b1a333f93be5a5de11148"
-  integrity sha512-Z+tkX9ah7G1pM/V9AF3KOetNJeD+R3Y1FZ+oDQvQAAKj3upr2RcsHEqAbNL+xDezkMdZUlZjnB7sXVbk3wFyrg==
+wireai-onboarding@0.5.0:
+  version "0.5.0"
+  resolved "https://registry.yarnpkg.com/wireai-onboarding/-/wireai-onboarding-0.5.0.tgz#17e78242fcd3cd7e19ae9462221b91741499020b"
+  integrity sha512-0/9/xnsnnEuBLBO52+LlLCeklfcISLFKwzxba1C1iHcYdNf4K6ngWaMnSr5AinMP1gKC/HbMFTEXg5593IgW8A==
 
 wireai-rn@^0.2.4:
   version "0.2.4"


### PR DESCRIPTION
## What

Bumps `wireai-onboarding` **0.2.1 → 0.5.0** (exact pin), lockfile regenerated. Tarball integrity `sha1-17e78242fcd3cd7e19ae9462221b91741499020b`.

This is the big-delta bump: it crosses the reviews module (0.3.0), the showcase color remaps (0.3.1/0.3.2 — CTA accent + calm hero panel), the identity/userId layer, the motion/design wave (0.4.0), and the dormant flags layer (0.5.0).

## API audit

Audited every kit surface the boilerplate imports against the 0.5.0 exports — the surface is **additive**, no compile break:

| Usage site | Kit API | 0.5.0 status |
|---|---|---|
| `wire-onboarding-screen.tsx` | `WireOnboarding`, `wireConfigFromEnv`, `isOnboardingEnabled`, `OnboardingResult`, `OnboardingEvent` | ✅ exported, props/shape unchanged (`OnboardingResult.answers` intact) |
| `wire-onboarding-screen.tsx`, `app-showcase.ts`, `select-showcase-slides.*` | `FeatureShowcase`, `ShowcaseConfig`, `ShowcaseSlide`, `selectShowcaseSlides` | ✅ all exported; `FeatureShowcaseProps { config, onDone, accentColor? }` unchanged; `selectShowcaseSlides` **now shipped** by the kit |
| `wire-onboarding-storage.ts` | `WireOnboardingStorage` | ✅ unchanged |
| `config/coachmarks.ts`, `home-screen.tsx`, `app.tsx`, `coachmark-storage.ts` | `CoachmarkProvider`, `CoachmarkStep`, `CoachmarkStorage`, `selectTourSteps`, `useCoachmarkAnchor`, `useCoachmarkTour` | ✅ all exported; `CoachmarkProviderProps`/`UseCoachmarkTourOptions` still accept every prop used (`tourId`, `enabled`, `startDelayMs`, `onStepShown`, `isTestingCoachmark`, `accentColor`) |

**Only code change:** corrected a now-stale TODO comment in `select-showcase-slides.ts`. It claimed the pinned 0.2.1 didn't export `selectShowcaseSlides`. The kit exports it as of 0.3.x, but the inline mirror is kept on purpose — the `wireai-onboarding/showcase` subpath loads native deps (`@blazejkustra/react-native-onboarding` + `react-native-reanimated`) at module load, so importing the helper as a runtime value here would pull those into the node test env and break the suite. The comment now explains that.

## Behavior deltas for boilerplate users (kit-internal defaults, no app code needed)

- **Review prompt** now renders as a **centered modal** by default (reviews module, 0.3.0). The boilerplate doesn't wire the reviews module yet, so no visible change here — noted for when you do.
- **Feature showcase** now paints the **calm hero panel + accent-colored CTA** (0.3.1/0.3.2 color remaps). Your `accentColor={theme.colors.primary}` still drives the CTA accent.
- **No step numbers** in the onboarding flow anymore (motion/design wave, 0.4.0) — the progress affordance is the animated bar, not "Step 2 of 5".
- Minor: `WireOnboarding`'s `onSkip` is retained for back-compat but per-question Skip is now **internal** — the callback is no longer wired to that control. The boilerplate's `handleSkip` still typechecks and still fires on the flow-level abandon path.

## Verification

- `yarn type:check` — clean
- `yarn test` — **63/63 passed, 7 suites** (unchanged count)

Off `development`. Do not squash-merge without review.