### PR TITLE
chore: bump wireai-onboarding 0.5.0 -> 0.6.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-native-worklets": "0.7.4",
     "react-redux": "^9.1.0",
     "redux-persist": "^6.0.0",
-    "wireai-onboarding": "0.5.0",
+    "wireai-onboarding": "0.6.0",
     "wireai-rn": "^0.2.4",
     "zod": "^3.22.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -6826,10 +6826,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wireai-onboarding@0.5.0:
-  version "0.5.0"
-  resolved "https://registry.yarnpkg.com/wireai-onboarding/-/wireai-onboarding-0.5.0.tgz#17e78242fcd3cd7e19ae9462221b91741499020b"
-  integrity sha512-0/9/xnsnnEuBLBO52+LlLCeklfcISLFKwzxba1C1iHcYdNf4K6ngWaMnSr5AinMP1gKC/HbMFTEXg5593IgW8A==
+wireai-onboarding@0.6.0:
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/wireai-onboarding/-/wireai-onboarding-0.6.0.tgz#a20efdc68429929522444923698958a67171a1ea"
+  integrity sha512-2z+yNoHYsD96W05WjcQCFBdm0nceJCiimhrBMyfHvwPwaCG0FfxedCoWHnmFOQK6sAgL/mpPDaVjoGxjFmoyAw==
 
 wireai-rn@^0.2.4:
   version "0.2.4"


### PR DESCRIPTION
Bump the Wire Activation onboarding kit from **0.5.0 → 0.6.0** (exact pin) in the open-source Expo boilerplate.

## Change
- `yarn add wireai-onboarding@0.6.0 --exact`; `yarn.lock` regenerated.
- Resolved shasum `a20efdc68429929522444923698958a67171a1ea`, positive integrity (`sha512-2z+yNoHYsD96W05WjcQCFBdm0nceJCiimhrBMyfHvwPwaCG0FfxedCoWHnmFOQK6sAgL/mpPDaVjoGxjFmoyAw==`).
- Peer `wireai-rn >=0.2.3` still satisfied at 0.2.4 (untouched).
- Diff is exactly 2 files (`package.json` + `yarn.lock`).

## 0.5.0 → 0.6.0 delta for THIS repo
**Active**
- Centered loader visible in the wire-onboarding flow.

**Dormant** (shipped in the kit but not wired here)
- ReviewGate is not mounted (verified by grep) → the review two-input change is dormant.
- Questionnaire kit module + flag dormant.
- API change is additive; all 10 kit-importing files still compile.

## Verification
- `yarn type:check` clean.
- Full `yarn test`: **7 suites, 63/63 passed** (unchanged from 0.5.0 baseline).

Do NOT merge yet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E5YoC4RSL4XW4RG9V3iTTS