### PR TITLE
chore(deps): promote @wireai/activation rename to development

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Wiring lives in `src/features/onboarding/screens/wire-onboarding-screen.tsx`
 ## 🧭 Guided tours & feature showcase
 
 Two more onboarding surfaces ship wired, both from the same kit
-(`wireai-onboarding`, subpath imports so the core stays dependency-free):
+(`@wireai/activation`, subpath imports so the core stays dependency-free):
 
 - a **feature showcase** — a few static intro slides shown once before onboarding, and
 - **coachmarks** — a performance-first guided tour that rings real UI elements on the

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-native-worklets": "0.7.4",
     "react-redux": "^9.1.0",
     "redux-persist": "^6.0.0",
-    "wireai-onboarding": "0.2.1",
+    "@wireai/activation": "^0.1.1",
     "wireai-rn": "^0.2.4",
     "zod": "^3.22.4"
   },

--- a/src/config/coachmarks.test.ts
+++ b/src/config/coachmarks.test.ts
@@ -1,10 +1,10 @@
-// `src/config/coachmarks.ts` imports the kit's `wireai-onboarding/coachmarks`
+// `src/config/coachmarks.ts` imports the kit's `@wireai/activation/coachmarks`
 // subpath, whose entry eagerly loads the native overlay stack (reanimated +
 // expo-blur) — not loadable under the node test env. We're unit-testing the
 // APP-owned pieces (the feature-map catalog + the `buildHomeTourSteps` seam), so
 // we mock the kit boundary with a faithful `selectTourSteps` mirroring its
 // documented contract. The kit's own package tests cover the real implementation.
-jest.mock("wireai-onboarding/coachmarks", () => ({
+jest.mock("@wireai/activation/coachmarks", () => ({
   selectTourSteps: <T extends { id: string }>(catalog: T[], selection?: string[]): T[] => {
     if (!selection) return catalog;
     const byId = new Map(catalog.map((step) => [step.id, step]));

--- a/src/config/coachmarks.ts
+++ b/src/config/coachmarks.ts
@@ -2,7 +2,7 @@
  * coachmarks.ts — the app's guided-tour "feature map".
  *
  * This is the ONE place you declare which UI elements get a coachmark, what each
- * one says, and where it lives. The kit (`wireai-onboarding/coachmarks`) owns the
+ * one says, and where it lives. The kit (`@wireai/activation/coachmarks`) owns the
  * animation, blur spotlight, ring, gesture hand, measuring, and one-overlay queue;
  * the app only declares WHERE things anchor and WHICH tour plays.
  *
@@ -22,8 +22,8 @@
  * what makes that upgrade a one-liner.
  */
 
-import type { CoachmarkStep } from "wireai-onboarding/coachmarks";
-import { selectTourSteps } from "wireai-onboarding/coachmarks";
+import type { CoachmarkStep } from "@wireai/activation/coachmarks";
+import { selectTourSteps } from "@wireai/activation/coachmarks";
 
 /**
  * QA replay flag. Wired into `<CoachmarkProvider isTestingCoachmark={...}>`.

--- a/src/entrypoints/app.tsx
+++ b/src/entrypoints/app.tsx
@@ -1,4 +1,5 @@
 import { NavigationContainer, type NavigationContainerRef } from "@react-navigation/native";
+import { CoachmarkProvider } from "@wireai/activation/coachmarks";
 import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
@@ -9,7 +10,6 @@ import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
-import { CoachmarkProvider } from "wireai-onboarding/coachmarks";
 import { useScreenTracking } from "#root/analytics";
 import { IS_TESTING_COACHMARK } from "#root/config/coachmarks";
 import { useAppInitializer } from "#root/entrypoints/hooks";
@@ -68,7 +68,7 @@ const AppContent: React.FC = () => {
       <KeyboardProvider>
         <SafeAreaProvider>
           {/*
-            Guided-tour engine (wireai-onboarding/coachmarks). Mounted ONCE here,
+            Guided-tour engine (@wireai/activation/coachmarks). Mounted ONCE here,
             around the NavigationContainer, so its overlay host is a root-level
             sibling of the whole app — that placement lets a coachmark ring + blur
             paint ABOVE the bottom tab bar (which react-navigation draws over

--- a/src/features/home/screens/home-screen.tsx
+++ b/src/features/home/screens/home-screen.tsx
@@ -1,5 +1,6 @@
 import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
 import { useNavigation } from "@react-navigation/native";
+import { useCoachmarkAnchor, useCoachmarkTour } from "@wireai/activation/coachmarks";
 import React, { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, ScrollView, View } from "react-native";
@@ -13,7 +14,6 @@ import Animated, {
   withSpring,
   withTiming,
 } from "react-native-reanimated";
-import { useCoachmarkAnchor, useCoachmarkTour } from "wireai-onboarding/coachmarks";
 import { analytics, EVENTS, FEATURE_NAMES } from "#root/analytics";
 import { buildHomeTourSteps, HOME_TOUR_ID } from "#root/config/coachmarks";
 import type { AppTabStackParamsList } from "#root/navigation/routes";
@@ -51,7 +51,7 @@ const HomeScreenComponent: React.FC = () => {
     navigation.navigate("Settings", { screen: "MainSettings" });
   }, [navigation]);
 
-  // ── Guided tour (wireai-onboarding/coachmarks) ──────────────────────────────
+  // ── Guided tour (@wireai/activation/coachmarks) ─────────────────────────────
   // Register the two most prominent interactive elements as tour anchors. The ids
   // MUST match the `anchorId`s declared in the feature map (src/config/coachmarks.ts).
   const viewTodosAnchor = useCoachmarkAnchor("home_view_todos");

--- a/src/features/onboarding/config/app-showcase.ts
+++ b/src/features/onboarding/config/app-showcase.ts
@@ -1,4 +1,4 @@
-import type { ShowcaseConfig } from "wireai-onboarding/showcase";
+import type { ShowcaseConfig } from "@wireai/activation/showcase";
 
 /**
  * app-showcase.ts — the pre-onboarding "app intro" slides.

--- a/src/features/onboarding/screens/wire-onboarding-screen.tsx
+++ b/src/features/onboarding/screens/wire-onboarding-screen.tsx
@@ -1,13 +1,13 @@
-import type React from "react";
-import { useCallback, useState } from "react";
 import {
   isOnboardingEnabled,
   type OnboardingEvent,
   type OnboardingResult,
   WireOnboarding,
   wireConfigFromEnv,
-} from "wireai-onboarding";
-import { FeatureShowcase } from "wireai-onboarding/showcase";
+} from "@wireai/activation";
+import { FeatureShowcase } from "@wireai/activation/showcase";
+import type React from "react";
+import { useCallback, useState } from "react";
 import { analytics, EVENTS } from "#root/analytics";
 import { logger } from "#root/services/logging";
 import { useAppDispatch } from "#root/store/store";
@@ -36,7 +36,7 @@ export const WireOnboardingScreen: React.FC = () => {
   const dispatch = useAppDispatch();
   const { theme } = useTheme();
 
-  // App-intro showcase (wireai-onboarding/showcase): 3 static slides shown ONCE
+  // App-intro showcase (@wireai/activation/showcase): 3 static slides shown ONCE
   // before onboarding starts. The kit gates it via the shared coachmark storage
   // (`wire_showcase_<id>_seen`) — if already seen it renders nothing and calls
   // `onDone` from an effect, so this state simply advances to the flow below.

--- a/src/features/onboarding/services/wire-onboarding-storage.ts
+++ b/src/features/onboarding/services/wire-onboarding-storage.ts
@@ -1,5 +1,5 @@
+import type { WireOnboardingStorage } from "@wireai/activation";
 import { createMMKV } from "react-native-mmkv";
-import type { WireOnboardingStorage } from "wireai-onboarding";
 
 /**
  * MMKV-backed storage adapter for the Wire AI onboarding kit.

--- a/src/services/storage/coachmark-storage.ts
+++ b/src/services/storage/coachmark-storage.ts
@@ -1,4 +1,4 @@
-import type { CoachmarkStorage } from "wireai-onboarding/coachmarks";
+import type { CoachmarkStorage } from "@wireai/activation/coachmarks";
 import { mmkv } from "./mmkv-storage";
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,6 +2467,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
+"@wireai/activation@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.1.1.tgz#bc7cfbb0fa35a11bf5e60883426f6600c499cad4"
+  integrity sha512-xhNJxeMIBInX4tjxYhjyxq9z0Q3Hl0dAtd4m7moXGF16a1dSA8HWGHs+jWcFyJAVtpVffUfdyHAc85SJfTlvdw==
+
 "@xmldom/xmldom@^0.8.8":
   version "0.8.11"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.11.tgz#b79de2d67389734c57c52595f7a7305e30c2d608"
@@ -6825,11 +6830,6 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-wireai-onboarding@0.1.12:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/wireai-onboarding/-/wireai-onboarding-0.1.12.tgz#851c076fb548733ca2b296a83151ae30731ed9e2"
-  integrity sha512-9CNsyN1yEUPoX0hOPkuljVwTSsmrGkOE9Ji5hunzscO8uyMpFOh+CMZ/gxVytnuJfFUSLI4B8MDjjuXxF2UJXw==
 
 wireai-rn@^0.2.4:
   version "0.2.4"


### PR DESCRIPTION
## Promote: `@wireai/activation` rename onto the trunk (`development`)

Brings today's package-rename work (kit `wireai-onboarding` -> scoped `@wireai/activation`) onto the release branch. This is the single commit `feat/wire-onboarding-and-payments` carries beyond the trunk — everything else (showcase value-bridge, version bumps) is already on `development`.

### What lands
- `70e8a20` chore(deps): rename `wireai-onboarding` -> `@wireai/activation` (PR #7)
  - package.json dep -> `"@wireai/activation": "^0.1.1"`
  - 9 import specifiers across 7 source files re-pointed (subpaths `/coachmarks`, `/showcase` preserved)
  - `jest.mock` string + doc-comments + README name refs updated
  - Pure name swap, no API delta.

### Verify (clean detached worktree at feat HEAD `70e8a20`, no WIP)
- `yarn install --frozen-lockfile` -> OK (resolves `@wireai/activation@0.1.1`; pre-existing peer-dep warnings only)
- `yarn type:check` (`tsc --noEmit`) -> OK
- `yarn test` (jest) -> **55/55 passing**, 6 suites
- grep-to-zero: **0** `wireai-onboarding` references in any tracked file (code and docs)

### Merger notes (divergence)
`feat` branches from `3030d71` (before the trunk's later commits), so a merge/rebase onto `development` conflicts in **3 files** — resolve toward the rename (`@wireai/activation`), keeping the trunk's showcase/value-bridge changes:
- `package.json` — keep `@wireai/activation` (trunk currently has `wireai-onboarding@0.6.0`)
- `yarn.lock` — regenerate to the `@wireai/activation` entry
- `src/features/onboarding/screens/wire-onboarding-screen.tsx` — keep trunk's value-bridge body + feat's import rename

### Version flag
package.json range is `^0.1.1` and the committed lockfile pins `@wireai/activation@0.1.1`. The kit was published today as `@wireai/activation@0.3.0`; `^0.1.1` will NOT resolve to 0.3.0. If 0.3.0 is the intended target, bump the range to `^0.3.0` and refresh the lockfile before/at merge.

Do not merge — fresh-eyes SDD merger gates this next.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
