### PR TITLE
chore(deps): rename wireai-onboarding -> @wireai/activation (fresh on development)

### DIFF
--- a/README.md
+++ b/README.md
@@ -331,7 +331,7 @@ Wiring lives in `src/features/onboarding/screens/wire-onboarding-screen.tsx`
 ## 🧭 Guided tours & feature showcase
 
 Two more onboarding surfaces ship wired, both from the same kit
-(`wireai-onboarding`, subpath imports so the core stays dependency-free):
+(`@wireai/activation`, subpath imports so the core stays dependency-free):
 
 - a **feature showcase** — a few static intro slides shown once before onboarding, and
 - **coachmarks** — a performance-first guided tour that rings real UI elements on the

--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-native-worklets": "0.7.4",
     "react-redux": "^9.1.0",
     "redux-persist": "^6.0.0",
-    "wireai-onboarding": "0.6.0",
+    "@wireai/activation": "^0.1.1",
     "wireai-rn": "^0.2.4",
     "zod": "^3.22.4"
   },

--- a/src/config/coachmarks.test.ts
+++ b/src/config/coachmarks.test.ts
@@ -1,10 +1,10 @@
-// `src/config/coachmarks.ts` imports the kit's `wireai-onboarding/coachmarks`
+// `src/config/coachmarks.ts` imports the kit's `@wireai/activation/coachmarks`
 // subpath, whose entry eagerly loads the native overlay stack (reanimated +
 // expo-blur) — not loadable under the node test env. We're unit-testing the
 // APP-owned pieces (the feature-map catalog + the `buildHomeTourSteps` seam), so
 // we mock the kit boundary with a faithful `selectTourSteps` mirroring its
 // documented contract. The kit's own package tests cover the real implementation.
-jest.mock("wireai-onboarding/coachmarks", () => ({
+jest.mock("@wireai/activation/coachmarks", () => ({
   selectTourSteps: <T extends { id: string }>(catalog: T[], selection?: string[]): T[] => {
     if (!selection) return catalog;
     const byId = new Map(catalog.map((step) => [step.id, step]));

--- a/src/config/coachmarks.ts
+++ b/src/config/coachmarks.ts
@@ -2,7 +2,7 @@
  * coachmarks.ts — the app's guided-tour "feature map".
  *
  * This is the ONE place you declare which UI elements get a coachmark, what each
- * one says, and where it lives. The kit (`wireai-onboarding/coachmarks`) owns the
+ * one says, and where it lives. The kit (`@wireai/activation/coachmarks`) owns the
  * animation, blur spotlight, ring, gesture hand, measuring, and one-overlay queue;
  * the app only declares WHERE things anchor and WHICH tour plays.
  *
@@ -22,8 +22,8 @@
  * what makes that upgrade a one-liner.
  */
 
-import type { CoachmarkStep } from "wireai-onboarding/coachmarks";
-import { selectTourSteps } from "wireai-onboarding/coachmarks";
+import type { CoachmarkStep } from "@wireai/activation/coachmarks";
+import { selectTourSteps } from "@wireai/activation/coachmarks";
 
 /**
  * QA replay flag. Wired into `<CoachmarkProvider isTestingCoachmark={...}>`.

--- a/src/entrypoints/app.tsx
+++ b/src/entrypoints/app.tsx
@@ -9,7 +9,7 @@ import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
-import { CoachmarkProvider } from "wireai-onboarding/coachmarks";
+import { CoachmarkProvider } from "@wireai/activation/coachmarks";
 import { useScreenTracking } from "#root/analytics";
 import { IS_TESTING_COACHMARK } from "#root/config/coachmarks";
 import { useAppInitializer } from "#root/entrypoints/hooks";
@@ -68,7 +68,7 @@ const AppContent: React.FC = () => {
       <KeyboardProvider>
         <SafeAreaProvider>
           {/*
-            Guided-tour engine (wireai-onboarding/coachmarks). Mounted ONCE here,
+            Guided-tour engine (@wireai/activation/coachmarks). Mounted ONCE here,
             around the NavigationContainer, so its overlay host is a root-level
             sibling of the whole app — that placement lets a coachmark ring + blur
             paint ABOVE the bottom tab bar (which react-navigation draws over

--- a/src/features/home/screens/home-screen.tsx
+++ b/src/features/home/screens/home-screen.tsx
@@ -13,7 +13,7 @@ import Animated, {
   withSpring,
   withTiming,
 } from "react-native-reanimated";
-import { useCoachmarkAnchor, useCoachmarkTour } from "wireai-onboarding/coachmarks";
+import { useCoachmarkAnchor, useCoachmarkTour } from "@wireai/activation/coachmarks";
 import { analytics, EVENTS, FEATURE_NAMES } from "#root/analytics";
 import { buildHomeTourSteps, HOME_TOUR_ID } from "#root/config/coachmarks";
 import type { AppTabStackParamsList } from "#root/navigation/routes";
@@ -51,7 +51,7 @@ const HomeScreenComponent: React.FC = () => {
     navigation.navigate("Settings", { screen: "MainSettings" });
   }, [navigation]);
 
-  // ── Guided tour (wireai-onboarding/coachmarks) ──────────────────────────────
+  // ── Guided tour (@wireai/activation/coachmarks) ──────────────────────────────
   // Register the two most prominent interactive elements as tour anchors. The ids
   // MUST match the `anchorId`s declared in the feature map (src/config/coachmarks.ts).
   const viewTodosAnchor = useCoachmarkAnchor("home_view_todos");

--- a/src/features/onboarding/config/app-showcase.ts
+++ b/src/features/onboarding/config/app-showcase.ts
@@ -1,4 +1,4 @@
-import type { ShowcaseConfig } from "wireai-onboarding/showcase";
+import type { ShowcaseConfig } from "@wireai/activation/showcase";
 
 /**
  * app-showcase.ts — the "app intro" slide catalog.

--- a/src/features/onboarding/config/select-showcase-slides.test.ts
+++ b/src/features/onboarding/config/select-showcase-slides.test.ts
@@ -1,4 +1,4 @@
-import type { ShowcaseSlide } from "wireai-onboarding/showcase";
+import type { ShowcaseSlide } from "@wireai/activation/showcase";
 import {
   selectAppShowcaseSlideIds,
   selectAppShowcaseSlides,

--- a/src/features/onboarding/config/select-showcase-slides.ts
+++ b/src/features/onboarding/config/select-showcase-slides.ts
@@ -1,4 +1,4 @@
-import type { ShowcaseSlide } from "wireai-onboarding/showcase";
+import type { ShowcaseSlide } from "@wireai/activation/showcase";
 
 /**
  * select-showcase-slides — turn the user's onboarding answers into the 2-3 showcase
@@ -64,14 +64,14 @@ export const selectAppShowcaseSlideIds = (
  * with a selection → only the listed ids, in that order, unknown ids skipped and
  * duplicates ignored.
  *
- * The kit DOES export an identical `selectShowcaseSlides` from `wireai-onboarding/showcase`
+ * The kit DOES export an identical `selectShowcaseSlides` from `@wireai/activation/showcase`
  * (since 0.3.x). We keep this inline mirror on purpose: that subpath loads the native
  * showcase stack (`@blazejkustra/react-native-onboarding` + `react-native-reanimated`) at
  * module load, so importing the helper as a runtime value here would drag those into the
  * node test env and break the unit tests. Inlining the tiny, pure body keeps this file
  * import-light and test-safe while teaching the exact same contract. (If you'd rather use
- * the kit helper, import it from `wireai-onboarding/showcase` and mock that subpath in the
- * test, the same way `coachmarks.test.ts` mocks `wireai-onboarding/coachmarks`.)
+ * the kit helper, import it from `@wireai/activation/showcase` and mock that subpath in the
+ * test, the same way `coachmarks.test.ts` mocks `@wireai/activation/coachmarks`.)
  */
 export const selectShowcaseSlides = <T extends { id: string }>(
   catalog: T[],

--- a/src/features/onboarding/screens/wire-onboarding-screen.tsx
+++ b/src/features/onboarding/screens/wire-onboarding-screen.tsx
@@ -6,9 +6,9 @@ import {
   type OnboardingResult,
   WireOnboarding,
   wireConfigFromEnv,
-} from "wireai-onboarding";
-import type { ShowcaseSlide } from "wireai-onboarding/showcase";
-import { FeatureShowcase } from "wireai-onboarding/showcase";
+} from "@wireai/activation";
+import type { ShowcaseSlide } from "@wireai/activation/showcase";
+import { FeatureShowcase } from "@wireai/activation/showcase";
 import { analytics, EVENTS } from "#root/analytics";
 import { logger } from "#root/services/logging";
 import { useAppDispatch } from "#root/store/store";
@@ -37,7 +37,7 @@ export const WireOnboardingScreen: React.FC = () => {
   const dispatch = useAppDispatch();
   const { theme } = useTheme();
 
-  // App-intro showcase (wireai-onboarding/showcase), rendered as a PERSONALIZED
+  // App-intro showcase (@wireai/activation/showcase), rendered as a PERSONALIZED
   // VALUE BRIDGE *after* onboarding completes: 2-3 slides picked from the user's
   // answers (see `select-showcase-slides.ts`). `null` = onboarding not finished yet;
   // a slide array = play the bridge, then enter the app. The kit still gates it once

--- a/src/features/onboarding/services/wire-onboarding-storage.ts
+++ b/src/features/onboarding/services/wire-onboarding-storage.ts
@@ -1,5 +1,5 @@
 import { createMMKV } from "react-native-mmkv";
-import type { WireOnboardingStorage } from "wireai-onboarding";
+import type { WireOnboardingStorage } from "@wireai/activation";
 
 /**
  * MMKV-backed storage adapter for the Wire AI onboarding kit.

--- a/src/services/storage/coachmark-storage.ts
+++ b/src/services/storage/coachmark-storage.ts
@@ -1,4 +1,4 @@
-import type { CoachmarkStorage } from "wireai-onboarding/coachmarks";
+import type { CoachmarkStorage } from "@wireai/activation/coachmarks";
 import { mmkv } from "./mmkv-storage";
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,6 +2467,11 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
+"@wireai/activation@^0.1.1":
+  version "0.1.1"
+  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.1.1.tgz#bc7cfbb0fa35a11bf5e60883426f6600c499cad4"
+  integrity sha512-xhNJxeMIBInX4tjxYhjyxq9z0Q3Hl0dAtd4m7moXGF16a1dSA8HWGHs+jWcFyJAVtpVffUfdyHAc85SJfTlvdw==
+
 "@xmldom/xmldom@^0.8.8":
   version "0.8.11"
   resolved "https://registry.yarnpkg.com/@xmldom/xmldom/-/xmldom-0.8.11.tgz#b79de2d67389734c57c52595f7a7305e30c2d608"
@@ -6825,11 +6830,6 @@ which@^2.0.1:
   integrity sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==
   dependencies:
     isexe "^2.0.0"
-
-wireai-onboarding@0.6.0:
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/wireai-onboarding/-/wireai-onboarding-0.6.0.tgz#a20efdc68429929522444923698958a67171a1ea"
-  integrity sha512-2z+yNoHYsD96W05WjcQCFBdm0nceJCiimhrBMyfHvwPwaCG0FfxedCoWHnmFOQK6sAgL/mpPDaVjoGxjFmoyAw==
 
 wireai-rn@^0.2.4:
   version "0.2.4"


### PR DESCRIPTION
## Fresh rename directly on `development`

Supersedes the conflicted feat->development PR #8. Applies the `wireai-onboarding` -> `@wireai/activation` package rename **fresh on the trunk** so there's no merge to fight.

### What changed
- **package.json** dep `wireai-onboarding@0.6.0` -> `"@wireai/activation": "^0.1.1"` (matches the other apps' pin; the `0.3.0` bump is Malik's separate call)
- **yarn.lock** resolved to `@wireai/activation@0.1.1`
- All source import specifiers re-pointed; subpaths (`/coachmarks`, `/showcase`) preserved
- `jest.mock("@wireai/activation/coachmarks", ...)` string updated (critical — mock keeps applying)
- doc-comments + README name ref updated

13 files, +28/-28. Pure name swap, no API delta.

### Rename sites (12 code/doc + lockfile)
- `package.json`, `yarn.lock`, `README.md`
- `src/config/coachmarks.ts`, `src/config/coachmarks.test.ts` (jest.mock)
- `src/entrypoints/app.tsx`
- `src/features/home/screens/home-screen.tsx`
- `src/features/onboarding/config/app-showcase.ts`
- `src/features/onboarding/config/select-showcase-slides.ts`, `select-showcase-slides.test.ts`
- `src/features/onboarding/screens/wire-onboarding-screen.tsx`
- `src/features/onboarding/services/wire-onboarding-storage.ts`
- `src/services/storage/coachmark-storage.ts`

### Verify
- `yarn install` -> OK (resolves `@wireai/activation@0.1.1` from npm)
- `yarn install --frozen-lockfile` -> OK (lockfile in sync)
- `yarn type:check` (`tsc --noEmit`) -> OK
- `yarn test` -> **63/63 passing**, 7 suites (coachmarks test proves the mock re-pointed)
- grep-to-zero: **0** `wireai-onboarding` refs in any tracked file (code + docs)

Pre-existing peer-dep / baseline-browser-mapping warnings only. Do not merge — fresh-eyes SDD gate next.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDSYZEyZ6RXHyurrmxSNsY