### PR TITLE
chore(deps): bump @wireai/activation 0.1.1 → 0.3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,7 +66,7 @@
     "react-native-worklets": "0.7.4",
     "react-redux": "^9.1.0",
     "redux-persist": "^6.0.0",
-    "@wireai/activation": "^0.1.1",
+    "@wireai/activation": "^0.3.0",
     "wireai-rn": "^0.2.4",
     "zod": "^3.22.4"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,10 +2467,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@wireai/activation@^0.1.1":
-  version "0.1.1"
-  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.1.1.tgz#bc7cfbb0fa35a11bf5e60883426f6600c499cad4"
-  integrity sha512-xhNJxeMIBInX4tjxYhjyxq9z0Q3Hl0dAtd4m7moXGF16a1dSA8HWGHs+jWcFyJAVtpVffUfdyHAc85SJfTlvdw==
+"@wireai/activation@^0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.3.0.tgz#7a299dac7dfb5cb05cd7591357ba9c66251f0d0c"
+  integrity sha512-bK/7R7J0W7plh7FG5KN76lYUAxircUvv4ytqih4nmHdqKP5h9OMctrlogBVk8La6kCsADi/LbcfUk+8EfNmcVQ==
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.11"


### PR DESCRIPTION
Bumps `@wireai/activation` from `^0.1.1` to `^0.3.0`. The delta is purely additive (new `/analytics` subpath; existing API unchanged).

## Verification
- Resolved version: `0.3.0`; `./analytics` present in package exports
- `yarn install --frozen-lockfile`: passes
- `yarn type:check`: 0 errors
- `yarn test` (jest): 63 passed / 7 suites, fully green

Only `package.json` + `yarn.lock` changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01GDSYZEyZ6RXHyurrmxSNsY