### PR TITLE
chore(deps): bump @wireai/activation 0.3.0 → 0.8.0 + rich user-context example

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,6 +38,7 @@
     "@reduxjs/toolkit": "^2.11.2",
     "@shopify/flash-list": "2.0.2",
     "@shopify/restyle": "^2.4.0",
+    "@wireai/activation": "^0.8.0",
     "expo": "^55.0.17",
     "expo-blur": "~55.0.15",
     "expo-build-properties": "~55.0.13",
@@ -66,7 +67,6 @@
     "react-native-worklets": "0.7.4",
     "react-redux": "^9.1.0",
     "redux-persist": "^6.0.0",
-    "@wireai/activation": "^0.3.0",
     "wireai-rn": "^0.2.4",
     "zod": "^3.22.4"
   },

--- a/src/features/auth/hooks/use-auth.ts
+++ b/src/features/auth/hooks/use-auth.ts
@@ -1,4 +1,5 @@
 import { useCallback } from "react";
+import { setWireUserContext } from "#root/features/onboarding/services/wire-analytics";
 import { useAppDispatch, useAppSelector } from "#root/store/store";
 import { useToast } from "#root/ui/hooks";
 import { useLoginMutation } from "../api/auth.api";
@@ -59,6 +60,17 @@ export const useAuth = () => {
           })
         );
 
+        // Wire AI rich user-context EXAMPLE — bind WHO this user is so activation
+        // analytics can segment by user. `device_key` + `app_version` are auto-provided
+        // by the kit (0.8.0); the host only sets the app-specific identity here.
+        // ⚠️ `userEmail` is opt-in PII (GDPR) — pass it only with consent. See the note
+        // on `setWireUserContext`. No-op until a Wire key is configured (fresh clones).
+        setWireUserContext({
+          userId: mockUser.id, // your app's OPAQUE user id (never the email)
+          userEmail: mockUser.email, // opt-in PII — raw by default; add `hashEmail: true` to hash on-device
+          // extra: { plan: "free" }, // ← any custom cohort dimension you have
+        });
+
         showSuccess("Login Successful", "Welcome back!");
         return { success: true };
       } catch (_error: unknown) {
@@ -104,6 +116,8 @@ export const useAuth = () => {
             tokens: savedTokens,
           })
         );
+        // Re-bind the Wire AI user-context on session restore (same pattern as login).
+        setWireUserContext({ userId: savedUser.id, userEmail: savedUser.email });
       }
     } catch (error) {
       console.error("Failed to check auth status:", error);

--- a/src/features/onboarding/services/wire-analytics.ts
+++ b/src/features/onboarding/services/wire-analytics.ts
@@ -1,0 +1,62 @@
+import type { WireUserContext } from "@wireai/activation";
+import { wireConfigFromEnv } from "@wireai/activation";
+import { type Analytics, createAnalytics } from "@wireai/activation/analytics";
+import { wireOnboardingStorage } from "./wire-onboarding-storage";
+
+/**
+ * Wire AI analytics — the rich user-context EXAMPLE.
+ *
+ * This is the second half of the `@wireai/activation` integration: the onboarding
+ * screen shows the AI flow, this shows how to feed the activation analytics the
+ * context that lets you segment WHO onboarded and on WHAT device.
+ *
+ * `createAnalytics` returns a Segment/PostHog-shaped surface (`track` / `screen` /
+ * `identify` / `setUserContext`) over the kit's own offline-first queue — no second
+ * SDK, no second key. It reuses the SAME `{ serverUrl, apiKey }` as onboarding (via
+ * `wireConfigFromEnv`) and the SAME MMKV storage seam as the onboarding session, so
+ * events survive being offline and an app kill.
+ *
+ * WHAT THE KIT AUTO-PROVIDES (0.8.0) — you do NOT set these:
+ *   • device (form factor + iOS model), auto-minted stable `device_key`, `app_version`.
+ *
+ * WHAT YOU SET (the app-specific identity) — see `setWireUserContext` + `use-auth.ts`:
+ *   • `userId`    your app's OPAQUE user id (NOT the email).
+ *   • `userEmail` OPT-IN PII (see the consent note on `setWireUserContext`).
+ *   • `extra`     any custom cohort dimensions (plan/tier/locale…), namespaced `custom.*`.
+ *
+ * GATING: identical to onboarding — when no Wire key is set (a fresh clone),
+ * `wireConfigFromEnv()` is `null`, `wireAnalytics` is `null`, and every helper is a
+ * no-op. Add a free Wire key to `.env` to light it up. Zero setup required.
+ */
+const config = wireConfigFromEnv();
+
+export const wireAnalytics: Analytics | null = config
+  ? createAnalytics({
+      serverUrl: config.serverUrl,
+      apiKey: config.apiKey,
+      appId: config.appId,
+      // Reuse the onboarding MMKV seam so pending events persist across an app kill.
+      storage: wireOnboardingStorage,
+      // Seeded ONCE here at init. `device_key` + `app_version` auto-fill (0.8.0), so the
+      // only thing missing is the user's identity — unknown until login. Attach it then
+      // via `setWireUserContext` (see `handleLogin` in `../../auth/hooks/use-auth.ts`).
+      userContext: {
+        // extra: { plan: "free" }, // ← example: a custom cohort dimension, if you have one
+      },
+    })
+  : null;
+
+/**
+ * Attach / update the rich user-context after init — call this at login (and on
+ * session restore) so every subsequent activation event carries who the user is.
+ * Shallow-merges over the current context (`extra` deep-merges); a supplied `userId`
+ * also binds like `identify`. No-op until a Wire key is configured.
+ *
+ * ⚠️ PII / consent: `userEmail` is personal data (GDPR — EU users). Only pass it once
+ * the user has consented. By default the RAW email is sent (the server stores it; the
+ * console shows only its hash). To send ONLY a hash FROM the device, pass
+ * `hashEmail: true` alongside `userEmail`.
+ */
+export const setWireUserContext = (partial: Partial<WireUserContext>): void => {
+  wireAnalytics?.setUserContext(partial);
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,10 +2467,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@wireai/activation@^0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.3.0.tgz#7a299dac7dfb5cb05cd7591357ba9c66251f0d0c"
-  integrity sha512-bK/7R7J0W7plh7FG5KN76lYUAxircUvv4ytqih4nmHdqKP5h9OMctrlogBVk8La6kCsADi/LbcfUk+8EfNmcVQ==
+"@wireai/activation@^0.8.0":
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.8.0.tgz#8207252c382733c2b3a4be9981cfbdebb6f48392"
+  integrity sha512-yo2LhTTamU/ClquZOvGi1JTBC+yqMGlKCcFpn7iIyurcYzePq5V9rmVkpNudVihRsTsTqyJxLt0BizOMrtcOqg==
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.11"


### PR DESCRIPTION
## What

Re-pins the activation kit from `^0.3.0` → **`^0.8.0`** (via `yarn add`, so `package.json` + `yarn.lock` move together) and wires the 0.8.0 **rich user-context** as a clean, documented EXAMPLE.

`node_modules/@wireai/activation/package.json` resolves **0.8.0**.

## API reconciliation

The 0.3.0 → 0.8.0 jump is a big version bump but **source-compatible for this boilerplate's usage** — `WireOnboarding`, `wireConfigFromEnv`, `isOnboardingEnabled`, `OnboardingEvent`/`OnboardingResult`, the `showcase` + `coachmarks` subpaths, and the `WireOnboardingStorage` adapter type all resolve unchanged. No breakage to fix; `tsc --noEmit` and the full jest suite pass as-is.

## The rich user-context example (what a buyer copies)

- **`src/features/onboarding/services/wire-analytics.ts`** (new) — a gated `createAnalytics` singleton over the SAME `{ serverUrl, apiKey }` + MMKV storage seam as onboarding, seeded with a `userContext`, plus a `setWireUserContext(partial)` helper. Gated on `wireConfigFromEnv()` so it's a **no-op on a fresh clone** (no key = no analytics), mirroring the existing onboarding gate.
- **`src/features/auth/hooks/use-auth.ts`** — binds `userId` (opaque) + `userEmail` at **login** and on **session restore** via `setWireUserContext`.

`device_key` + `app_version` auto-fill in 0.8.0, so the host only sets the app-specific identity (`userId` / `userEmail` / optional `extra`).

## PII / consent note

`userEmail` is **opt-in PII** (GDPR — EU users): only pass it with consent. Per Malik's ruling the example sends the **RAW email by default** (server stores it; the console shows only the hash). To send **only a hash from the device**, add `hashEmail: true` alongside `userEmail` in `setWireUserContext` — documented inline in both files.

## Verification

- `yarn type:check` → clean
- `yarn test` → **63 passed, 7 suites**
- `yarn lint:check` on the two touched files → clean

## Not in scope

- Sibling boilerplates `Standard_AiMobileLauncher` / `AI_AiMobileLauncher` have **no** `@wireai/activation` pin — nothing stale to bump there.
- `yarn lint:check` reports pre-existing `organizeImports` debt on 4 untouched files (`app.tsx`, `home-screen.tsx`, `wire-onboarding-screen.tsx`, `wire-onboarding-storage.ts`) — left alone (out of scope).

Do NOT merge / EAS — review only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01WsGkrwsVMyMS4yMdxkTUQp