### PR TITLE
chore(deps): bump @wireai/activation 0.8.0 → 0.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,28 @@
+# Changelog
+
+All notable changes to this boilerplate are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
+
+## [Unreleased]
+
+### Changed
+
+- Bumped `@wireai/activation` `^0.8.0` → `^0.10.0` (2026-07-19). The lockfile
+  now resolves to exactly `0.10.0`. What the bump brings:
+  - the kit-owned event-trigger surface `wire.track()` / `useWireActivation()`
+    plus decision revalidation (kit #49);
+  - a cross-bundle session singleton
+    (`globalThis[Symbol.for("@wireai/activation:currentSessionId")]`) so
+    `getCurrentSessionId()` is reliable when the kit runs from `dist`;
+  - the 0.9.2 `retainSessionOnComplete` funnel-seed fix (one signup = one
+    `session_started`);
+  - the 0.9.1 review-decision truth fixes.
+  - No consumer code changes required: every symbol this template imports
+    (`WireOnboarding`, `wireConfigFromEnv`, `isOnboardingEnabled`,
+    `WireOnboardingStorage`, `OnboardingResult`, `OnboardingEvent`, and the
+    `@wireai/activation/showcase` + `@wireai/activation/coachmarks` subpath
+    exports) is unchanged in 0.10.0. Typecheck, the Jest suite, and the Expo JS
+    bundle all pass on the bump.
+  - Not adopted in this pass: the new `wire.track()` event API is available but
+    intentionally left unwired here (a separate, deliberate follow-up).

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@reduxjs/toolkit": "^2.11.2",
     "@shopify/flash-list": "2.0.2",
     "@shopify/restyle": "^2.4.0",
-    "@wireai/activation": "^0.8.0",
+    "@wireai/activation": "^0.10.0",
     "expo": "^55.0.17",
     "expo-blur": "~55.0.15",
     "expo-build-properties": "~55.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,10 +2467,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@wireai/activation@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.8.0.tgz#8207252c382733c2b3a4be9981cfbdebb6f48392"
-  integrity sha512-yo2LhTTamU/ClquZOvGi1JTBC+yqMGlKCcFpn7iIyurcYzePq5V9rmVkpNudVihRsTsTqyJxLt0BizOMrtcOqg==
+"@wireai/activation@^0.10.0":
+  version "0.10.0"
+  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.10.0.tgz#aed7237a1e7bddf662af374e2eb7e4188917548e"
+  integrity sha512-liRnuoO/NT77l29OjlPOnkwCIz5Cjh+YVRRaJQVCh5gid3WZi2dXAYUxLHHccEV3jkMHgKP/EDyoku+XMrYctg==
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.11"


### PR DESCRIPTION
## Re-pin `@wireai/activation` → `0.10.0` (consumer hygiene)

Part of the cross-repo wave re-pinning every Wire AI consumer to `@wireai/activation@0.10.0`. This is the **boilerplate** lane.

### What changed (3 files, mechanical)
- `package.json`: `@wireai/activation` `^0.8.0` → `^0.10.0` (kept the repo's caret convention; lockfile resolves to exactly **0.10.0**).
- `yarn.lock`: updated (yarn 1).
- `CHANGELOG.md`: **created** (first entry) documenting the bump.

No template/app code was touched. Every symbol this boilerplate imports from the kit is unchanged in 0.10.0.

### Base-branch note (important)
The handoff listed the current pin as `^0.3.0`, but that reflects a **stale local checkout**. The real `development` tip (PR #11) already sits at `^0.8.0`, so the actual jump is **0.8.0 → 0.10.0** (2 minors), not 0.3 → 0.10. Branched off `origin/development`.

### Verification — all GREEN
| Check | Result |
|---|---|
| `yarn type:check` (`tsc --noEmit`) | PASS |
| `yarn test:ci` (Jest) | **63/63** pass, 7 suites |
| `npx expo export` (iOS JS bundle) | PASS — 1915 modules bundled, no errors |

### API-surface audit (0.8.0 → 0.10.0)
No break points. All imports resolve unchanged: `WireOnboarding`, `wireConfigFromEnv`, `isOnboardingEnabled`, `WireOnboardingStorage`, `OnboardingResult`, `OnboardingEvent` (main entry) and `FeatureShowcase` / `ShowcaseSlide` / `ShowcaseConfig` (`/showcase`), `CoachmarkProvider` / `useCoachmarkTour` / `useCoachmarkAnchor` / `selectTourSteps` / `CoachmarkStep` / `CoachmarkStorage` (`/coachmarks`).

### Metro plugin — NOT required here (recommendation only)
The kit's 0.10.0 README wires Metro via `withWireOnboarding(getDefaultConfig(__dirname))`. This boilerplate's `metro.config.js` does **not** use it, and the Expo JS bundle build still succeeds cleanly (Metro resolves the kit's `src` through the existing babel config, no duplicate-React error). So adopting `withWireOnboarding` is a **future alignment**, not a blocker — deliberately left out of this hygiene PR to keep it mechanical.

### Not in scope
- No adoption of the new `wire.track()` / `useWireActivation()` event API (separate deliberate follow-up).
- No consumer app-version bump.
- Do **not** merge without review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01G4bUqa1i42L8z3BvKNb1rB