### PR TITLE
fix(metro): wire the @wireai/activation Metro helper

### DIFF
--- a/metro.config.js
+++ b/metro.config.js
@@ -1,4 +1,5 @@
 const { getDefaultConfig } = require('expo/metro-config');
+const { withWireOnboarding } = require('@wireai/activation/metro');
 
 const config = getDefaultConfig(__dirname);
 
@@ -14,4 +15,11 @@ config.resolver.alias = {
   '#store': './src/store',
 };
 
-module.exports = config;
+// ── @wireai/activation (closed-source kit, consumed from npm) ─────────────────
+// The kit's `withWireOnboarding` Metro helper (npm mode) non-destructively pins
+// single-instance deps (react / react-native / wireai-rn / zod) to THIS app's
+// node_modules — two React instances crash RN. The kit's package.json `exports`
+// `react-native` condition points Metro at the kit's shipped `src`, so Metro
+// still transforms it. This app's `config.resolver.alias` (above) and all other
+// defaults are preserved.
+module.exports = withWireOnboarding(config);


### PR DESCRIPTION
## Summary
- `metro.config.js` was still plain `getDefaultConfig` even though `@wireai/activation` (`^0.10.0`) is a dependency here.
- Every other kit consumer wraps Metro with the kit's `withWireOnboarding` helper from `@wireai/activation/metro`, which non-destructively pins a single copy of `react` / `react-native` / `wireai-rn` / `zod` to this app's own `node_modules` (a second React instance crashes RN) and arms the kit's optional-module handling.
- Mirrors `morrow_app_mobile/metro.config.js` exactly (the only consumer repo that actually had the wrapper wired at the time of this fix — see caveat below). The existing `#root`/`#features`/etc path-alias mapping is untouched.

## Caveat found while building this
`Standard_AiMobileLauncher/metro.config.js` — expected to be the reference per the original ask — does **not** currently have the wrapper either, despite listing `@wireai/activation` as a dependency. `morrow_app_mobile` was used as the actual reference instead, since it's the one repo that has this wired correctly. Flagging in case Standard needs the same fix in a follow-up.

## Test plan
- [x] `node -e "require('./metro.config.js')"` loads clean, `resolver.alias` untouched, `resolver.extraNodeModules` pins `react`/`react-native`/`wireai-rn`/`zod` to this app's `node_modules`, `watchFolders` unaffected (npm-consumer mode, no `source` override).
- [ ] `expo start -c` once merged, to clear the Metro cache after the config change (per the kit's own integration notes).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_016TN2Ruk8R766KGBV8gVcVw