### PR TITLE
docs: add Wire AI ecosystem section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -684,6 +684,19 @@ Lessons get captured into a memory bank that survives across sessions, so contri
 
 ---
 
+## The Wire AI ecosystem
+
+[Wire AI](https://getwireai.com) is the AI-native growth engineer for mobile apps: one agent that runs four versions of every step of your users' journey, live at once, and keeps what makes them stay. This starter is one piece of that ecosystem:
+
+- **Wire RN SDK** (`wireai-rn`): the open-source React Native SDK that renders Wire's AI-driven flows as native components in your app. https://github.com/chohra-med/wireai-rn
+- **Expo boilerplate** (you are here): an open-source Expo starter wired for Wire AI activation out of the box.
+- **Claude skills**: skills for each part of the app (SDK integration, the question script, the learning loop) that explain and drive the work from inside your editor.
+- **Hosted MCP server**: connect Claude, Cursor, or any MCP client to Wire's hosted server at `https://wireai-mcp.fly.dev/mcp` with an `Authorization: Bearer <key>` header to read your funnel and run the improve loop. Nothing runs from your repo.
+
+The activation kit ships as [`@wireai/activation`](https://www.npmjs.com/package/@wireai/activation) on npm.
+
+---
+
 ## 📄 License
 
 MIT — see the [LICENSE](LICENSE) file for details.


### PR DESCRIPTION
Adds a 'Wire AI ecosystem' section (Wire RN SDK + Expo boilerplate + Claude skills + hosted MCP server) with current platform positioning. Docs-only.