### PR TITLE
chore(wire): mount useLifecycleEvents at app root for funnel denominator

### DIFF
--- a/src/entrypoints/app.tsx
+++ b/src/entrypoints/app.tsx
@@ -9,10 +9,12 @@ import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
+import { useLifecycleEvents } from "@wireai/activation";
 import { CoachmarkProvider } from "@wireai/activation/coachmarks";
 import { useScreenTracking } from "#root/analytics";
 import { IS_TESTING_COACHMARK } from "#root/config/coachmarks";
 import { useAppInitializer } from "#root/entrypoints/hooks";
+import { wireLifecycleConfig } from "#root/features/onboarding/services/wire-lifecycle";
 import { RootStackNavigator } from "#root/navigation/navigators/root-stack-navigator";
 import type { RootStackParamList } from "#root/navigation/routes";
 import { coachmarkStorage } from "#root/services/storage";
@@ -31,6 +33,11 @@ const AppContent: React.FC = () => {
 
   // Boot core services (Firebase Analytics + Crashlytics + RevenueCat) and emit APP_OPEN.
   useAppInitializer();
+
+  // Wire funnel denominator: fire app.first_open (once ever) + app.session_started
+  // (per open) so the tenant's activation/retention rates have something to divide by.
+  // No-op until a Wire key is configured. See services/wire-lifecycle.ts.
+  useLifecycleEvents(wireLifecycleConfig);
 
   // Screen tracking: emits SCREEN_VIEW / SCREEN_EXIT through the analytics facade.
   const { onScreenChange } = useScreenTracking();

--- a/src/features/onboarding/services/wire-lifecycle.ts
+++ b/src/features/onboarding/services/wire-lifecycle.ts
@@ -1,0 +1,33 @@
+import type { LifecycleConfig } from "@wireai/activation";
+import { wireConfigFromEnv } from "@wireai/activation";
+import { wireOnboardingStorage } from "./wire-onboarding-storage";
+
+/**
+ * Wire AI lifecycle events — the funnel DENOMINATOR.
+ *
+ * `useLifecycleEvents` (mounted ONCE at the app root — see `src/entrypoints/app.tsx`)
+ * fires `app.first_open` (once ever, per install) + `app.session_started` (once per
+ * open). These two events are the funnel denominator: without them a Wire tenant has
+ * nothing to divide by, so activation and retention are unrankable rates.
+ *
+ * This config reuses the SAME `{ serverUrl, apiKey, appId }` as onboarding (via
+ * `wireConfigFromEnv`) and the SAME MMKV storage seam as the onboarding session, so
+ * the once-ever first-open flag survives an app kill and lifecycle events buffer
+ * offline — no second SDK, no second key.
+ *
+ * GATING: identical to onboarding + analytics — when no Wire key is set (a fresh
+ * clone), `wireConfigFromEnv()` is `null`, this is `undefined`, and the hook no-ops.
+ * Add a free Wire key to `.env` to light it up. Zero setup required.
+ */
+const config = wireConfigFromEnv();
+
+export const wireLifecycleConfig: LifecycleConfig | undefined = config
+  ? {
+      serverUrl: config.serverUrl,
+      apiKey: config.apiKey,
+      appId: config.appId,
+      // Reuse the onboarding MMKV seam: persists the once-ever first-open flag and
+      // buffers lifecycle events across an app kill.
+      storage: wireOnboardingStorage,
+    }
+  : undefined;


### PR DESCRIPTION
## What changed

Mount the kit's `useLifecycleEvents` hook (from `@wireai/activation` 0.11.0, already pinned) **once at the app root** in `src/entrypoints/app.tsx` — same place the Wire integration (`CoachmarkProvider` / `WireOnboarding`) is mounted.

- `src/features/onboarding/services/wire-lifecycle.ts` (new): builds the `LifecycleConfig` from `wireConfigFromEnv()` + the existing onboarding MMKV storage seam (`wireOnboardingStorage`). Mirrors the gating + wiring pattern of the sibling `wire-analytics.ts` — no second SDK, no second key. Resolves to `undefined` (hook no-ops) when no Wire key is set.
- `src/entrypoints/app.tsx`: one hook call — `useLifecycleEvents(wireLifecycleConfig)` — inside `AppContent`, next to `useAppInitializer` / `useScreenTracking`.

## Why (audit finding)

From the 2026-07-21 Wire consumer architecture audit. Without `useLifecycleEvents`, the free boilerplate never fires `app.first_open` / `app.session_started`. No open events means **no funnel denominator**: a tenant's activation and retention are unrankable rates. This is change (d) of the wave-2 consumer cleanup.

## Test evidence

- `yarn type:check` (`tsc --noEmit`) → green.
- `yarn test` (jest) → **7 suites, 63 tests, all pass**.
- `git diff origin/development...HEAD --stat` → only the two intended files (40 insertions).

Note: `yarn biome check` flags `organizeImports` on `app.tsx` — this failure is **pre-existing on trunk** (the unmodified `origin/development:src/entrypoints/app.tsx` fails the same check with exit 1). Not touched to avoid a drive-by formatting sweep; the new file `wire-lifecycle.ts` is biome-clean.

⛔ report-and-wait, do not merge — Malik reviews.

🤖 Generated with [Claude Code](https://claude.com/claude-code)