### PR TITLE
chore(wire): upgrade @wireai/activation to 0.13.6 and wireai-rn to 0.2.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,66 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ### Changed
 
+- Bumped `@wireai/activation` `^0.11.0` → **`0.13.6`** and `wireai-rn` `^0.2.4` →
+  **`0.2.5`** (2026-08-17), both pinned EXACTLY (no caret) with `yarn.lock`
+  regenerated in the same commit. `^0.11.0` is a 0.x caret, so it resolved to
+  `>=0.11.0 <0.12.0` — the pin is what makes the version readable from
+  `package.json` alone.
+  (The earlier `^0.10.0` → `^0.11.0` bump shipped without a changelog entry. This
+  entry covers the whole `0.11.0 → 0.13.6` range.)
+
+  **What the range brings, in order of how much it bites the default config:**
+  - **0.13.3 — the loading screen could hang forever.** `maxRetries` never
+    re-armed, so on the DEFAULT `maxRetries={1}` exactly one retry ever fired and
+    no terminal state was reached: a backend hung at start gave a 15s loader and
+    then a permanent "Getting started…", with `fallbackFlow` unreachable. This
+    boilerplate's onboarding screen has always promised "a backend error degrades
+    to the static flow" — that promise is only actually kept from this version on.
+  - **0.13.3 — a retry could be recorded as the user's first answer.** The
+    kickoff payload was keyed on a mount-time prop, so a retry re-sent
+    `startMessage` and the server recorded it as the answer to the pending
+    question. Only the first attempt of a fresh session sends it now. Stated
+    cost: a retry SKIPS a pending card, so the user loses one question.
+  - **0.12.2 / 0.13.0 — the `device_key` join key** (see Fixed below).
+  - **0.13.5 — `wireDoctor`**, a dev-only integration self-check on
+    `@wireai/activation/analytics`. Available, deliberately not wired here yet.
+  - **0.13.6 — `OnboardingResult.plan` and `.variant`**, the backend's plan and
+    the assigned experiment arm handed to the host uninterpreted. Both keys are
+    absent (not `undefined`) when the backend sends neither, so `handleComplete`
+    is unaffected. `wireai-rn@0.2.5` is what surfaces the extra DataPart the
+    `plan` read needs; `0.2.4` simply reads no plan.
+  - `DoneBlock` and `RESERVED_USER_CONTEXT_KEYS` were removed in 0.13.0. Neither
+    is referenced anywhere in `src/` — verified, no action needed.
+  - No import site changed. All six `@wireai/activation` subpaths this template
+    uses (root, `/showcase`, `/analytics`, `/coachmarks`) still resolve, and the
+    `selectTourSteps` mock in `src/config/coachmarks.test.ts` still mirrors the
+    real 0.13.6 contract exactly.
+
+### Fixed
+
+- **The Wire onboarding storage adapter now reports failure instead of faking
+  success** (`src/features/onboarding/services/wire-onboarding-storage.ts`).
+  Every method used to swallow its MMKV error and resolve as if the call had
+  worked. Since kit 0.13.0 that is actively harmful: the kit decides whether it
+  may auto-inject `user_context.device_key` — the only thing that joins an
+  onboarding session to everything the app reports later — by asking whether the
+  write actually SUCCEEDED, not whether a `storage` prop was passed. An adapter
+  that always reports success makes that gate inert, so a locked / full /
+  permission-denied MMKV silently produces a NEW join key on every launch, which
+  corrupts the server's `min_sessions` counter instead of merely leaving the join
+  empty. `getItem` / `setItem` / `removeItem` now reject on a real failure; every
+  kit consumer already catches, so onboarding still never breaks. Covered by
+  `wire-onboarding-storage.test.ts` (8 tests; the three rejection cases fail
+  against the old adapter).
+
+- **Stale comments corrected.** `wire-analytics.ts` credited the auto-minted
+  `device_key` to "(0.8.0)" and described it as unconditionally stable; stability
+  has depended on the storage adapter since 0.13.0. The onboarding screen now
+  documents what `storage` actually buys (session resume AND the join key) and
+  why no `userContext` is passed here.
+
+### Changed (earlier)
+
 - Bumped `@wireai/activation` `^0.8.0` → `^0.10.0` (2026-07-19). The lockfile
   now resolves to exactly `0.10.0`. What the bump brings:
   - the kit-owned event-trigger surface `wire.track()` / `useWireActivation()`

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@reduxjs/toolkit": "^2.11.2",
     "@shopify/flash-list": "2.0.2",
     "@shopify/restyle": "^2.4.0",
-    "@wireai/activation": "^0.11.0",
+    "@wireai/activation": "0.13.6",
     "expo": "^55.0.17",
     "expo-blur": "~55.0.15",
     "expo-build-properties": "~55.0.13",
@@ -67,7 +67,7 @@
     "react-native-worklets": "0.7.4",
     "react-redux": "^9.1.0",
     "redux-persist": "^6.0.0",
-    "wireai-rn": "^0.2.4",
+    "wireai-rn": "0.2.5",
     "zod": "^3.22.4"
   },
   "devDependencies": {

--- a/src/entrypoints/app.tsx
+++ b/src/entrypoints/app.tsx
@@ -1,4 +1,6 @@
 import { NavigationContainer, type NavigationContainerRef } from "@react-navigation/native";
+import { useLifecycleEvents } from "@wireai/activation";
+import { CoachmarkProvider } from "@wireai/activation/coachmarks";
 import { useFonts } from "expo-font";
 import * as SplashScreen from "expo-splash-screen";
 import { StatusBar } from "expo-status-bar";
@@ -9,8 +11,6 @@ import { KeyboardProvider } from "react-native-keyboard-controller";
 import { SafeAreaProvider } from "react-native-safe-area-context";
 import { Provider } from "react-redux";
 import { PersistGate } from "redux-persist/integration/react";
-import { useLifecycleEvents } from "@wireai/activation";
-import { CoachmarkProvider } from "@wireai/activation/coachmarks";
 import { useScreenTracking } from "#root/analytics";
 import { IS_TESTING_COACHMARK } from "#root/config/coachmarks";
 import { useAppInitializer } from "#root/entrypoints/hooks";

--- a/src/features/home/screens/home-screen.tsx
+++ b/src/features/home/screens/home-screen.tsx
@@ -1,5 +1,6 @@
 import type { BottomTabNavigationProp } from "@react-navigation/bottom-tabs";
 import { useNavigation } from "@react-navigation/native";
+import { useCoachmarkAnchor, useCoachmarkTour } from "@wireai/activation/coachmarks";
 import React, { useCallback, useEffect, useMemo } from "react";
 import { useTranslation } from "react-i18next";
 import { Pressable, ScrollView, View } from "react-native";
@@ -13,7 +14,6 @@ import Animated, {
   withSpring,
   withTiming,
 } from "react-native-reanimated";
-import { useCoachmarkAnchor, useCoachmarkTour } from "@wireai/activation/coachmarks";
 import { analytics, EVENTS, FEATURE_NAMES } from "#root/analytics";
 import { buildHomeTourSteps, HOME_TOUR_ID } from "#root/config/coachmarks";
 import type { AppTabStackParamsList } from "#root/navigation/routes";

--- a/src/features/onboarding/screens/wire-onboarding-screen.tsx
+++ b/src/features/onboarding/screens/wire-onboarding-screen.tsx
@@ -1,5 +1,3 @@
-import type React from "react";
-import { useCallback, useState } from "react";
 import {
   isOnboardingEnabled,
   type OnboardingEvent,
@@ -9,6 +7,8 @@ import {
 } from "@wireai/activation";
 import type { ShowcaseSlide } from "@wireai/activation/showcase";
 import { FeatureShowcase } from "@wireai/activation/showcase";
+import type React from "react";
+import { useCallback, useState } from "react";
 import { analytics, EVENTS } from "#root/analytics";
 import { logger } from "#root/services/logging";
 import { useAppDispatch } from "#root/store/store";
@@ -26,6 +26,12 @@ import { OnboardingScreen as StaticOnboardingScreen } from "./onboarding-screen"
  * this renders the Wire AI dynamic onboarding. The kit's `fallbackFlow` is the
  * SAME static questionnaire this boilerplate has always shipped, so a backend /
  * generation error degrades to the static flow instead of breaking onboarding.
+ *
+ * ⚠️ That last sentence only became TRUE at kit 0.13.3. On the default
+ * `maxRetries={1}` the retry never re-armed, so a backend that hung at start left
+ * the user on the loading screen FOREVER and `fallbackFlow` was unreachable. The
+ * defaults now mean what they say (`1` → two kickoff attempts, then the fallback),
+ * which is why this screen passes no `maxRetries` / `startTimeoutMs` of its own.
  *
  * When no key is set (a fresh clone), `isOnboardingEnabled()` is false and the
  * static flow renders unchanged — zero setup required. Add a free Wire key to
@@ -100,6 +106,28 @@ export const WireOnboardingScreen: React.FC = () => {
     <Box flex={1}>
       <WireOnboarding
         config={config}
+        // `storage` does TWO jobs, and the second one is the whole funnel.
+        //
+        // 1. RESUME: persists the session-correlation id, so an app kill mid-flow
+        //    resumes the same backend session instead of counting a phantom drop.
+        // 2. THE JOIN KEY: since kit 0.12.2 a `storage` prop also lets the kit
+        //    auto-inject `user_context.device_key` — the ONLY thing that stitches
+        //    this onboarding session to every event the app reports later. Without
+        //    it the `activated` funnel reads a silent zero, which is how two of
+        //    three production integrations shipped.
+        //
+        // We deliberately pass NO `userContext` here. This app owns no device id of
+        // its own, and the key the kit mints is the SAME one `wire-analytics.ts` and
+        // `wire-lifecycle.ts` stamp (one process-wide registry, namespaced by
+        // `appId`, persisted in the MMKV instance all three share) — so the join is
+        // already correct. Hand-writing `userContext={{ deviceKey }}` would produce a
+        // bucket the server does not read; if you ever DO own a device id, pass it as
+        // `userContext={activationJoinContext(yourDeviceKey)}` and it wins verbatim.
+        //
+        // ⚠️ The auto-join only fires if the adapter really persists. Since 0.13.0
+        // the kit gates injection on a write that SUCCEEDED, not on the prop being
+        // present — which is why `wire-onboarding-storage.ts` rejects on failure
+        // instead of pretending. Read the note there before you "harden" it.
         storage={wireOnboardingStorage}
         fallbackFlow={<StaticOnboardingScreen />}
         onComplete={handleComplete}

--- a/src/features/onboarding/services/wire-analytics.ts
+++ b/src/features/onboarding/services/wire-analytics.ts
@@ -16,8 +16,18 @@ import { wireOnboardingStorage } from "./wire-onboarding-storage";
  * `wireConfigFromEnv`) and the SAME MMKV storage seam as the onboarding session, so
  * events survive being offline and an app kill.
  *
- * WHAT THE KIT AUTO-PROVIDES (0.8.0) — you do NOT set these:
- *   • device (form factor + iOS model), auto-minted stable `device_key`, `app_version`.
+ * WHAT THE KIT AUTO-PROVIDES — you do NOT set these:
+ *   • device (form factor + iOS model), `app_version`, and the per-install
+ *     `device_key` the kit mints and persists for you.
+ *
+ * ⚠️ `device_key` is auto-minted, but it is only STABLE across launches if this
+ * storage adapter actually persists it (kit 0.13.0 made that distinction real —
+ * see `wire-onboarding-storage.ts`). It is the same id the onboarding screen's
+ * auto-join injects: one process-wide registry keyed by `appId`, one MMKV slot
+ * (`wireai:analytics:deviceKey:<appId>`), so onboarding and analytics land in ONE
+ * id space and the `activated` funnel can actually join them. That only holds
+ * while all three Wire surfaces share this storage instance and this `appId` —
+ * splitting either one splits the funnel, silently.
  *
  * WHAT YOU SET (the app-specific identity) — see `setWireUserContext` + `use-auth.ts`:
  *   • `userId`    your app's OPAQUE user id (NOT the email).
@@ -37,9 +47,9 @@ export const wireAnalytics: Analytics | null = config
       appId: config.appId,
       // Reuse the onboarding MMKV seam so pending events persist across an app kill.
       storage: wireOnboardingStorage,
-      // Seeded ONCE here at init. `device_key` + `app_version` auto-fill (0.8.0), so the
-      // only thing missing is the user's identity — unknown until login. Attach it then
-      // via `setWireUserContext` (see `handleLogin` in `../../auth/hooks/use-auth.ts`).
+      // Seeded ONCE here at init. `device_key` + `app_version` auto-fill, so the only
+      // thing missing is the user's identity — unknown until login. Attach it then via
+      // `setWireUserContext` (see `handleLogin` in `../../auth/hooks/use-auth.ts`).
       userContext: {
         // extra: { plan: "free" }, // ← example: a custom cohort dimension, if you have one
       },

--- a/src/features/onboarding/services/wire-onboarding-storage.test.ts
+++ b/src/features/onboarding/services/wire-onboarding-storage.test.ts
@@ -1,0 +1,96 @@
+// The adapter builds its OWN dedicated MMKV instance at import time (deliberately
+// separate from the redux-persist store), so the global `createMMKV` mock in
+// jest.setup.js gives us a fresh object we cannot reach. Re-mock here and hand back
+// one stable instance, then read it off the factory's recorded result.
+jest.mock("react-native-mmkv", () => {
+  const instance = { getString: jest.fn(), set: jest.fn(), remove: jest.fn() };
+  return { createMMKV: jest.fn(() => instance) };
+});
+
+import { createMMKV } from "react-native-mmkv";
+import { wireOnboardingStorage } from "./wire-onboarding-storage";
+
+const mmkv = (createMMKV as unknown as jest.Mock).mock.results[0].value as {
+  getString: jest.Mock;
+  set: jest.Mock;
+  remove: jest.Mock;
+};
+
+const FAILURE = new Error("mmkv: storage is full");
+
+describe("wireOnboardingStorage (async MMKV adapter)", () => {
+  beforeEach(() => {
+    mmkv.getString.mockReset();
+    mmkv.set.mockReset();
+    mmkv.remove.mockReset();
+  });
+
+  describe("the happy path", () => {
+    it("resolves the stored string for a present key", async () => {
+      mmkv.getString.mockReturnValue("wsess_abc");
+      await expect(wireOnboardingStorage.getItem("wireai:session:default")).resolves.toBe(
+        "wsess_abc"
+      );
+      expect(mmkv.getString).toHaveBeenCalledWith("wireai:session:default");
+    });
+
+    it("coalesces a missing key (MMKV returns undefined) to null", async () => {
+      mmkv.getString.mockReturnValue(undefined);
+      // The kit's contract is `string | null`; a bare undefined would break it.
+      await expect(wireOnboardingStorage.getItem("never_written")).resolves.toBeNull();
+    });
+
+    it("writes through and resolves", async () => {
+      await expect(
+        wireOnboardingStorage.setItem("wireai:analytics:deviceKey:default", "wdev_x")
+      ).resolves.toBeUndefined();
+      expect(mmkv.set).toHaveBeenCalledWith("wireai:analytics:deviceKey:default", "wdev_x");
+    });
+
+    it("removes and resolves", async () => {
+      await expect(
+        wireOnboardingStorage.removeItem("wireai:session:default")
+      ).resolves.toBeUndefined();
+      expect(mmkv.remove).toHaveBeenCalledWith("wireai:session:default");
+    });
+  });
+
+  // These four are the reason this adapter exists in its current shape. Before kit
+  // 0.13.0 every method swallowed its error and resolved as if it had worked, which
+  // made a locked / full / permission-denied MMKV indistinguishable from a healthy
+  // one. The kit gates the auto-injected `device_key` join key on a write that
+  // genuinely SUCCEEDED, so a fabricated success there means a fresh per-launch key
+  // on the wire — which corrupts `min_sessions` instead of merely leaving the join
+  // empty. A failure has to reach the caller. See the note in the adapter.
+  describe("a failing MMKV must REJECT, never fake success", () => {
+    it("rejects a failed write instead of resolving", async () => {
+      mmkv.set.mockImplementation(() => {
+        throw FAILURE;
+      });
+      await expect(wireOnboardingStorage.setItem("k", "v")).rejects.toThrow(
+        "mmkv: storage is full"
+      );
+    });
+
+    it("rejects a failed read instead of reporting an empty slot", async () => {
+      mmkv.getString.mockImplementation(() => {
+        throw FAILURE;
+      });
+      // Resolving `null` here would read as "nothing stored yet", so the kit would
+      // mint and re-persist a NEW id on every launch and never know it had failed.
+      await expect(wireOnboardingStorage.getItem("k")).rejects.toThrow(FAILURE);
+    });
+
+    it("rejects a failed remove instead of resolving", async () => {
+      mmkv.remove.mockImplementation(() => {
+        throw FAILURE;
+      });
+      await expect(wireOnboardingStorage.removeItem("k")).rejects.toThrow(FAILURE);
+    });
+
+    it("still resolves null for a genuinely absent key, so absence stays distinguishable", async () => {
+      mmkv.getString.mockReturnValue(undefined);
+      await expect(wireOnboardingStorage.getItem("k")).resolves.toBeNull();
+    });
+  });
+});

--- a/src/features/onboarding/services/wire-onboarding-storage.ts
+++ b/src/features/onboarding/services/wire-onboarding-storage.ts
@@ -1,47 +1,60 @@
-import { createMMKV } from "react-native-mmkv";
 import type { WireOnboardingStorage } from "@wireai/activation";
+import { createMMKV } from "react-native-mmkv";
 
 /**
  * MMKV-backed storage adapter for the Wire AI onboarding kit.
  *
- * The kit persists ONLY its own session-correlation id (never answers) so an app
- * kill mid-onboarding resumes the same backend session instead of minting a new
- * one (keeping the analytics funnel honest). It expects the AsyncStorage-compatible
- * subset — `getItem` / `setItem` / `removeItem` — which we satisfy with a small,
- * dedicated MMKV instance (kept separate from the redux-persist store).
+ * The kit persists its own session-correlation id (never answers) so an app kill
+ * mid-onboarding resumes the same backend session instead of minting a new one
+ * (keeping the analytics funnel honest), plus the per-install `device_key` that
+ * joins onboarding to every event the app reports later. It expects the
+ * AsyncStorage-compatible subset — `getItem` / `setItem` / `removeItem` — which we
+ * satisfy with a small, dedicated MMKV instance (kept separate from the
+ * redux-persist store). The SAME instance is handed to analytics and lifecycle, so
+ * all three surfaces share one id.
+ *
+ * ── WHY THESE METHODS REJECT INSTEAD OF SWALLOWING (0.13.0) ───────────────────
+ * This adapter used to catch every MMKV error and resolve as if the call had
+ * worked: `setItem` swallowed and resolved `void`, `getItem` swallowed and
+ * resolved `null`. That reads as defensive, and it is the opposite.
+ *
+ * Since 0.13.0 the kit decides whether it may put an auto-minted `device_key` on
+ * the wire by asking whether the write actually SUCCEEDED — it grants
+ * `IdentityRecord.durable` only when a persisted id was read back or a `setItem`
+ * RESOLVED (`node_modules/@wireai/activation/src/context/deviceId.ts:162-176`),
+ * and `<WireOnboarding>` injects the join key only on `durable`
+ * (`node_modules/@wireai/activation/src/WireOnboarding.tsx:182`). An adapter that
+ * reports success unconditionally makes that gate inert: a locked / full /
+ * permission-denied MMKV looks identical to a healthy one, so the kit persists
+ * nothing, mints a fresh `wdev_*` on every launch, and injects it. A per-launch
+ * join key is worse than none — the server counts `min_sessions` by distinct opens
+ * grouped on `device_key`, so it corrupts that counter instead of leaving it empty.
+ *
+ * Rejecting is safe: EVERY kit consumer of this adapter already catches. The
+ * session read is wrapped in try/catch (`session/persistedSession.ts:99-103`), and
+ * every write is fire-and-forget with `.catch(() => {})` (`persistedSession.ts:137`,
+ * `permissions/permissionMemory.ts:72`, `analytics/eventQueue.ts:286`,
+ * `session-analytics/lifecycle.ts:193`). So a failing device still onboards
+ * normally — the kit just declines the join key and says why in a dev warning,
+ * which is the outcome you want, because it is the true one.
+ *
+ * The rule to take away: a storage seam must report what really happened. Faking
+ * success does not make persistence more reliable, it only removes everything
+ * downstream's ability to notice that it failed.
  */
 const mmkv = createMMKV({ id: "wire-onboarding-storage" });
 
 export const wireOnboardingStorage: WireOnboardingStorage = {
-  getItem: (key: string): Promise<string | null> => {
-    return new Promise((resolve) => {
-      try {
-        resolve(mmkv.getString(key) ?? null);
-      } catch {
-        resolve(null);
-      }
-    });
+  // `async` on a synchronous MMKV call is deliberate: the kit's interface is
+  // promise-based, and an async function turns a native throw into a REJECTED
+  // promise, which is exactly the signal the durability gate reads.
+  getItem: async (key: string): Promise<string | null> => mmkv.getString(key) ?? null,
+
+  setItem: async (key: string, value: string): Promise<void> => {
+    mmkv.set(key, value);
   },
 
-  setItem: (key: string, value: string): Promise<void> => {
-    return new Promise((resolve) => {
-      try {
-        mmkv.set(key, value);
-      } catch {
-        // best-effort — persistence must never break onboarding
-      }
-      resolve();
-    });
-  },
-
-  removeItem: (key: string): Promise<void> => {
-    return new Promise((resolve) => {
-      try {
-        mmkv.remove(key);
-      } catch {
-        // best-effort
-      }
-      resolve();
-    });
+  removeItem: async (key: string): Promise<void> => {
+    mmkv.remove(key);
   },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,10 +2467,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@wireai/activation@^0.11.0":
-  version "0.11.0"
-  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.11.0.tgz#52c4b90ea51482e10647244bdd5bdef79c359808"
-  integrity sha512-xlon5IwU+8Mjk5qm3dDWlMFQO2FRV2ChB7L4InD+jF8rYvgvk0EuZOf04YN3saL2jxpVz51NPiIwgy2bphWTvw==
+"@wireai/activation@0.13.6":
+  version "0.13.6"
+  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.13.6.tgz#c9930efbe1ef9c94040afae7c443e8ecde11b652"
+  integrity sha512-hUVimfzua0V0R/CYy4CLVV5veNokOua04rzN1SXGw+yBbnUxxylB0kWkVHBHm6siSLdUQ9Q2EaS+cxPp6pIOsg==
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.11"
@@ -6831,10 +6831,10 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-wireai-rn@^0.2.4:
-  version "0.2.4"
-  resolved "https://registry.yarnpkg.com/wireai-rn/-/wireai-rn-0.2.4.tgz#19a8a0dca400b19757fa73f4784a8e4630725ff7"
-  integrity sha512-0Z4F1tu1PNzgUg3kN9FekTVV8imYQx6d1p781Ih5KawmfI0BHpWHaJe1xwD3/FO9Q387Y7ojoZcbuKg4v8lgIQ==
+wireai-rn@0.2.5:
+  version "0.2.5"
+  resolved "https://registry.yarnpkg.com/wireai-rn/-/wireai-rn-0.2.5.tgz#a95f3aa793e12cfd253624b9700e7c9c4c9e12d4"
+  integrity sha512-6i3jOW+UcyhP1rZHlAdktPA+vlg4UCAEchPySt2jfQw09A5y4NV1nZS8gghjiWF0uvfHjEwNA3BDm8x7KJX2PA==
 
 wordwrap@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Upgrades the Wire AI integration from `@wireai/activation@^0.11.0` to **`0.13.6`** and `wireai-rn@^0.2.4` to **`0.2.5`**, both exact-pinned with `yarn.lock` regenerated in the same commit.

`^0.11.0` is a 0.x caret, so npm resolved it to `>=0.11.0 <0.12.0`. Pinning is what makes the shipped version readable from `package.json` alone, matching how `morrow_app_mobile` pins them.

## Why this is not just a version bump

Nothing in the `0.11.0 → 0.13.6` range is labelled breaking, every import site still resolves, and `tsc` was green before any code change. **The risk here was semantic, not compile-time**, so this PR is the result of reading the kit source rather than trusting a green build.

### 🔴 The join key — the finding this upgrade turns on

`user_context.device_key` is the only thing that stitches an onboarding session to everything the app reports later. Without it the `activated` funnel reads a silent zero, which is how two of three production integrations shipped.

- **0.12.2** added auto-injection: the kit mints and injects its own key when a `storage` prop is present.
- **0.13.0** tightened the gate. It no longer trusts the *presence* of the `storage` prop; it requires a write that genuinely **succeeded** — `IdentityRecord.durable`, granted only when a persisted id was read back or a `setItem` **resolved**.

Which is where this repo had a problem. `wire-onboarding-storage.ts` caught every MMKV error and resolved as if the call had worked: `setItem` swallowed and resolved `void`, `getItem` swallowed and resolved `null`. That looks defensive and is the opposite — a locked / full / permission-denied MMKV was **indistinguishable from success** at that seam, so:

1. the kit would grant `durable: true` on a write that never landed,
2. persist nothing,
3. mint a fresh `wdev_*` on the next launch, and inject that,
4. and a per-launch join key is **worse than none** — the server counts `min_sessions` by distinct opens grouped on `device_key`, so it corrupts that counter instead of leaving the join empty.

**Verdict: auto-join does fire here, but only because the adapter manufactured the success signal.** The 0.13.0 safety gate was inert. The fix is to make the adapter honest — `getItem` / `setItem` / `removeItem` now reject on a real failure, so the gate can do the job it was built for.

Verified safe before changing it: **every** kit consumer of this adapter already catches a rejection — the session read is in a `try/catch`, and every write is fire-and-forget with `.catch(() => {})`. A failing device still onboards normally; the kit just declines the join key and says why in a dev warning, which is the outcome you want because it is the true one.

The call site deliberately passes **no `userContext`**. This app owns no device id of its own, and the key the kit mints is the same one `wire-analytics.ts` and `wire-lifecycle.ts` stamp (one process-wide registry, one MMKV slot, matching `appId`), so auto-join produces a correct join. Hand-writing `userContext={{ deviceKey }}` would produce a bucket the server does not read.

### The rest of the range

- **0.13.3 — the loading screen could hang forever.** `maxRetries` never re-armed, so on the default `maxRetries={1}` exactly one retry ever fired and no terminal state was reached: a hung backend gave a 15s loader and then a permanent "Getting started…", with `fallbackFlow` unreachable. This screen has always promised "a backend error degrades to the static flow" — that promise is only actually kept from this version on, and the comment now says so.
- **0.13.3 — a retry could be recorded as the user's first answer.** Silent answer-data corruption, now fixed upstream. Stated cost: a retry SKIPS a pending card, so the user loses one question.
- **0.13.6 — `OnboardingResult.plan` / `.variant`.** Both keys are absent (not `undefined`) when the backend sends neither, so `handleComplete` is unaffected. `wireai-rn@0.2.5` is what surfaces the extra DataPart the `plan` read needs.
- **`DoneBlock` / `RESERVED_USER_CONTEXT_KEYS`** were removed in 0.13.0. Neither appears anywhere in `src/` — re-verified, not assumed.
- The `selectTourSteps` mock in `src/config/coachmarks.test.ts` was checked against the real 0.13.6 implementation and still mirrors its contract exactly (same generic bound, same absent-selection identity return, same dedupe / skip-unknown / selection-order behaviour).

## Test evidence

`yarn validate` (type:check + lint:check + test:ci) — **green**.

| | baseline (trunk, untouched) | after |
|---|---|---|
| `tsc --noEmit` | pass | pass |
| `biome check src/` | **4 errors** (pre-existing) | 0 errors |
| `jest` | 7 suites / 63 tests | **8 suites / 71 tests** |

The 8 new tests pin the storage adapter's contract. They are a real control, not a restatement of the diff: the three rejection cases were run against the **old** swallowing adapter and go **red** (`3 failed, 5 passed`), then green against the new one.

## Scope

Case B only — `src/features/**`, `src/config/**`, entry points, `package.json`. **Nothing under `src/services/**` or `src/ui/**` was touched**; that is the shared layer and belongs in `Standard_AiMobileLauncher` first.

The second commit is isolated on purpose: `biome check` was **already red on `development`** with 4 `organizeImports` errors, so `yarn validate` could not pass on trunk at all. Two are fixed inside the upgrade commit (files it edits), the other two are a separate, import-reordering-only commit.

## Notes for the reviewer

- **`.memory/50-progress.md` was updated locally but is NOT in this diff — `.memory/*` is gitignored in this repo** (`.gitignore:50`), alongside `.cursor/*`. Deliberately not force-added: this is a boilerplate that ships to buyers, and those are internal AI files the ignore rule exists to keep out of a published tree.
- `wireDoctor` (0.13.5, dev-only self-check) is **available and deliberately not wired**, to keep this PR to the upgrade. Its storage probe verifies by read-back, so it would have caught exactly the adapter defect fixed here — worth a follow-up.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
