### PR TITLE
docs(wire): explicit Wire AI signup path + kill the dead server URL

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -6,7 +6,7 @@ EXPO_PUBLIC_SUPABASE_ANON_KEY=your-anon-key
 EXPO_PUBLIC_APP_ENV=development
 
 # ─────────────────────────────────────────────────────────────────────────────
-# AI Onboarding (Wire AI) — OPTIONAL, but ON by default when a key is present.
+# Wire AI onboarding: OPTIONAL, but ON by default when a key is present.
 # Leave these unset and onboarding renders the built-in static questionnaire
 # (zero setup). Set the key + server URL and the SAME screen renders Wire AI's
 # backend-driven onboarding flow. The static flow stays as an automatic fallback.

--- a/.env.example
+++ b/.env.example
@@ -8,11 +8,11 @@ EXPO_PUBLIC_APP_ENV=development
 # ─────────────────────────────────────────────────────────────────────────────
 # AI Onboarding (Wire AI) — OPTIONAL, but ON by default when a key is present.
 # Leave these unset and onboarding renders the built-in static questionnaire
-# (zero setup). Set the key + server URL to upgrade the SAME screen to AI-driven
-# dynamic onboarding — the static flow stays as an automatic fallback.
-# Create your account at https://getwireai.com/signup, then copy the app's API key
-# and app id from https://getwireai.com/console. Full steps in the README, section
-# "Get your Wire AI keys".
+# (zero setup). Set the key + server URL and the SAME screen renders Wire AI's
+# backend-driven onboarding flow. The static flow stays as an automatic fallback.
+# Get these from https://getwireai.com/signup, then read them back any time in
+# your console at https://getwireai.com/console. Full steps are in the README
+# under "Get your Wire AI keys".
 # ─────────────────────────────────────────────────────────────────────────────
 # EXPO_PUBLIC_WIREAI_API_KEY=wai_your_key_here
 # EXPO_PUBLIC_WIREAI_SERVER_URL=https://wire-rn-dynamic-onboarding.fly.dev

--- a/.env.example
+++ b/.env.example
@@ -10,10 +10,12 @@ EXPO_PUBLIC_APP_ENV=development
 # Leave these unset and onboarding renders the built-in static questionnaire
 # (zero setup). Set the key + server URL to upgrade the SAME screen to AI-driven
 # dynamic onboarding — the static flow stays as an automatic fallback.
-# Grab a free key at https://getwireai.com
+# Create your account at https://getwireai.com/signup, then copy the app's API key
+# and app id from https://getwireai.com/console. Full steps in the README, section
+# "Get your Wire AI keys".
 # ─────────────────────────────────────────────────────────────────────────────
-# EXPO_PUBLIC_WIREAI_API_KEY=your-wire-ai-tenant-key
-# EXPO_PUBLIC_WIREAI_SERVER_URL=https://your-wire-ai-server.com
+# EXPO_PUBLIC_WIREAI_API_KEY=wai_your_key_here
+# EXPO_PUBLIC_WIREAI_SERVER_URL=https://wire-rn-dynamic-onboarding.fly.dev
 # EXPO_PUBLIC_WIREAI_APP_ID=your-app-id
 
 # ─────────────────────────────────────────────────────────────────────────────

--- a/README.md
+++ b/README.md
@@ -346,8 +346,8 @@ starter flow. Real onboarding, recorded in your funnel, but no model calls yet. 
 the AI-generated flow is a manual step today: ask for it by email and it gets switched on for
 your app. The analytics, the funnel and the static flow all work immediately.
 
-The env vars in one block. See the day-one note above for what runs before the AI flow is
-switched on.
+Set these in `.env` to turn it on. See the day-one note above for what runs before the AI
+flow is switched on.
 
 ```env
 EXPO_PUBLIC_WIREAI_API_KEY=wai_your_key_here

--- a/README.md
+++ b/README.md
@@ -313,14 +313,15 @@ questionnaire otherwise, the exact same flow this boilerplate has always shipped
 - **No key set (fresh clone):** `isOnboardingEnabled()` is `false`, so the static
   questionnaire renders unchanged. Zero setup.
 - **Key set:** the screen renders `<WireOnboarding>` with your static flow passed
-  as `fallbackFlow`, so a backend/generation error degrades to the static flow
-  instead of breaking onboarding. Session persistence uses a small MMKV adapter.
+  as `fallbackFlow`, so if the flow cannot be fetched or the backend fails it degrades
+  to the static flow instead of breaking onboarding. Session persistence uses a small
+  MMKV adapter.
 
 ### Get your Wire AI keys
 
-The AI onboarding is off until you give it a key. Without one the app runs its built-in
-static questionnaire, so a fresh clone works with zero setup. Adding a key is what
-upgrades that same screen to AI-driven onboarding.
+Onboarding runs the app's built-in static questionnaire until you add a Wire AI key,
+so a fresh clone works with zero setup. Adding a key upgrades that same screen to
+Wire AI's backend-driven onboarding flow.
 
 1. **Create your account** at [getwireai.com/signup](https://getwireai.com/signup). You
    give it an app name and your email.

--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ questionnaire otherwise, the exact same flow this boilerplate has always shipped
 ### Get your Wire AI keys
 
 The AI onboarding is off until you give it a key. Without one the app runs its built-in
-static questionnaire, so a fresh clone works with zero setup, adding a key is what
+static questionnaire, so a fresh clone works with zero setup. Adding a key is what
 upgrades that same screen to AI-driven onboarding.
 
 1. **Create your account** at [getwireai.com/signup](https://getwireai.com/signup). You
@@ -328,7 +328,7 @@ upgrades that same screen to AI-driven onboarding.
 3. **Open the [console](https://getwireai.com/console).** Your app is already there, created
    from the name you gave at signup. Add another app any time you need a second key.
 4. **Copy the app's API key (`wai_…`) and its app id.** The key lives in the console, so you
-   can read it back later, you do not have to save it now.
+   can read it back later, and you do not have to save it now.
 5. **Paste them into `.env`** (copy `.env.example` first):
 
    ```bash
@@ -341,7 +341,7 @@ upgrades that same screen to AI-driven onboarding.
    inlined at build time, so a running bundler will not pick them up.
 
 **What you get on day one:** a new app starts on the free plan running a short scripted
-starter flow, real onboarding, recorded in your funnel, but no model calls yet. Turning on
+starter flow. Real onboarding, recorded in your funnel, but no model calls yet. Turning on
 the AI-generated flow is a manual step today: ask for it by email and it gets switched on for
 your app. The analytics, the funnel and the static flow all work immediately.
 

--- a/README.md
+++ b/README.md
@@ -316,11 +316,40 @@ questionnaire otherwise, the exact same flow this boilerplate has always shipped
   as `fallbackFlow`, so a backend/generation error degrades to the static flow
   instead of breaking onboarding. Session persistence uses a small MMKV adapter.
 
+### Get your Wire AI keys
+
+The AI onboarding is off until you give it a key. Without one the app runs its built-in
+static questionnaire, so a fresh clone works with zero setup, adding a key is what
+upgrades that same screen to AI-driven onboarding.
+
+1. **Create your account** at [getwireai.com/signup](https://getwireai.com/signup). You
+   give it an app name and your email.
+2. **Confirm the email** and set your password. That is your console login.
+3. **Open the [console](https://getwireai.com/console).** Your app is already there, created
+   from the name you gave at signup. Add another app any time you need a second key.
+4. **Copy the app's API key (`wai_…`) and its app id.** The key lives in the console, so you
+   can read it back later, you do not have to save it now.
+5. **Paste them into `.env`** (copy `.env.example` first):
+
+   ```bash
+   EXPO_PUBLIC_WIREAI_API_KEY=wai_your_key_here
+   EXPO_PUBLIC_WIREAI_SERVER_URL=https://wire-rn-dynamic-onboarding.fly.dev
+   EXPO_PUBLIC_WIREAI_APP_ID=your-app-id
+   ```
+
+6. **Restart Metro with the cache cleared** (`yarn start -c`). `EXPO_PUBLIC_*` values are
+   inlined at build time, so a running bundler will not pick them up.
+
+**What you get on day one:** a new app starts on the free plan running a short scripted
+starter flow, real onboarding, recorded in your funnel, but no model calls yet. Turning on
+the AI-generated flow is a manual step today: ask for it by email and it gets switched on for
+your app. The analytics, the funnel and the static flow all work immediately.
+
 Add a free key to upgrade:
 
 ```env
-EXPO_PUBLIC_WIREAI_API_KEY=your-wire-ai-tenant-key
-EXPO_PUBLIC_WIREAI_SERVER_URL=https://your-wire-ai-server.com
+EXPO_PUBLIC_WIREAI_API_KEY=wai_your_key_here
+EXPO_PUBLIC_WIREAI_SERVER_URL=https://wire-rn-dynamic-onboarding.fly.dev
 EXPO_PUBLIC_WIREAI_APP_ID=your-app-id
 ```
 

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ Three reasons to use it over `npx create-expo-app`:
 
 - **Feature-First Architecture** — organized by business features, not technical layers
 - **Authentication** — complete login system with secure token storage
-- **AI activation by default** — Wire AI finds what makes your users stay: a dynamic onboarding runs when a key is configured, with the built-in static questionnaire as an automatic fallback (add a free key to switch it on)
+- **AI activation by default**: Wire AI finds what makes your users stay, and once a key is configured the onboarding screen renders Wire AI's backend-driven onboarding flow, with the built-in static questionnaire as an automatic fallback (setup steps under "Get your Wire AI keys")
 - **Internationalization** — English and French language support
 - **Theming** — Light/Dark/System theme support with Restyle
 - **State Management** — Redux Toolkit with RTK Query
@@ -305,9 +305,9 @@ mkdir -p src/features/new-feature/{api,components,hooks,screens,services,store,t
 
 ## 🤖 AI activation by default
 
-Wire AI finds what makes your users stay, and this boilerplate ships ready for it.
-The `OnboardingFlow` screen renders [Wire AI](https://getwireai.com) dynamic
-onboarding when a key is configured, and falls back to the built-in static
+[Wire AI](https://getwireai.com) finds what makes your users stay, and this boilerplate
+ships ready for it. The `OnboardingFlow` screen renders Wire AI's backend-driven
+onboarding flow when a key is configured, and falls back to the built-in static
 questionnaire otherwise, the exact same flow this boilerplate has always shipped.
 
 - **No key set (fresh clone):** `isOnboardingEnabled()` is `false`, so the static
@@ -345,7 +345,8 @@ starter flow. Real onboarding, recorded in your funnel, but no model calls yet. 
 the AI-generated flow is a manual step today: ask for it by email and it gets switched on for
 your app. The analytics, the funnel and the static flow all work immediately.
 
-Add a free key to upgrade:
+The env vars in one block. See the day-one note above for what runs before the AI flow is
+switched on.
 
 ```env
 EXPO_PUBLIC_WIREAI_API_KEY=wai_your_key_here


### PR DESCRIPTION
## Why

A buyer clones the boilerplate and has no way to know how to switch the AI on. The README said only *"grab a free key at getwireai.com"*, with no steps, and the env block shipped `https://your-wire-ai-server.com`. That host does not exist, so anyone who copied it got a config that could never work.

Malik's ask: *"if a person use the boilerplate, we need to explicitly says he need to register in wire ai, create an account, add an app and use the keys there."*

## What changed (docs only, 2 files)

- **README.md**: new `### Get your Wire AI keys` section inside "AI activation by default". Six numbered steps: signup, confirm the email and set a password, open the console, copy the `wai_…` key and app id, paste into `.env`, restart Metro with the cache cleared. Plus a day-one paragraph stating what a fresh app actually does.
- **README.md + .env.example**: the dead placeholder `https://your-wire-ai-server.com` is replaced with the real server URL `https://wire-rn-dynamic-onboarding.fly.dev` (`GET /health` returns 200). The key placeholder now shows the real `wai_` shape.
- **.env.example**: the pointer names the signup and console URLs and the README section, instead of the bare homepage.

## Honesty guardrail

The day-one paragraph is load-bearing, not filler. A new tenant runs a **scripted static flow with zero model calls**; turning on the AI-generated flow is a manual step today. Nothing here implies a fresh signup runs the AI. No prices, no quotas, no percentages, no seat counts, no real key.

## Copy consistency

The section text comes verbatim from the shared context pack `00-Meta/SDD/handoffs/2026-08-17-launcher-readme-wire-signup.md` so the three boilerplate READMEs do not drift. Per-repo adjustments made here:

- step 6 uses this repo's own command, `yarn start -c` (the pack's default was `npx expo start -c`).
- three em dashes in the pack's copy were removed, because the house voice rule is zero em dashes. The pack has since been corrected and the canonical resolution applied here (period, period, `, and`) is the same one the Standard and AI lanes are using, so the block stays byte-identical across the three READMEs. Meaning unchanged.

## Gates (unchanged from trunk `1dafcda`)

| Command | Result |
|---|---|
| `yarn type:check` | green, `Done in 2.65s` |
| `yarn test:ci` | 8 suites passed, 71 tests passed |
| `yarn lint:check` | `Checked 157 files. No fixes applied.` |

`grep -n "your-wire-ai-server.com" README.md .env.example` returns nothing. `wire-rn-dynamic-onboarding.fly.dev` appears in both files.

Not touched: `src/`, `jest.setup.js`, `CLAUDE.md`, the "Wire AI ecosystem" section, and `.memory/` (gitignored in this repo, `.gitignore:50`). `launcher-sync` was not run: README and `.env.example` are per-app files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

