### PR TITLE
chore(deps): re-pin @wireai/activation 0.13.6 -> 0.14.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@reduxjs/toolkit": "^2.11.2",
     "@shopify/flash-list": "2.0.2",
     "@shopify/restyle": "^2.4.0",
-    "@wireai/activation": "0.13.6",
+    "@wireai/activation": "0.14.1",
     "expo": "^55.0.17",
     "expo-blur": "~55.0.15",
     "expo-build-properties": "~55.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,10 +2467,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@wireai/activation@0.13.6":
-  version "0.13.6"
-  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.13.6.tgz#c9930efbe1ef9c94040afae7c443e8ecde11b652"
-  integrity sha512-hUVimfzua0V0R/CYy4CLVV5veNokOua04rzN1SXGw+yBbnUxxylB0kWkVHBHm6siSLdUQ9Q2EaS+cxPp6pIOsg==
+"@wireai/activation@0.14.1":
+  version "0.14.1"
+  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.14.1.tgz#b6e00f8216acb4f9af01039607ae7855d7008754"
+  integrity sha512-9zfKn53Yjbk/lP6hagDY1Q9o+3zEo+QfIXALn2Wq85O4JHTIB44av224hbgTInNOmENc7VQemKAaaFJOKvX3jQ==
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.11"


### PR DESCRIPTION
Bumps `@wireai/activation` from `0.13.6` to `0.14.1` and regenerates `yarn.lock` in the same commit. Diff is exactly two files, no other dependency, code or config change.

## Why

0.14.1 carries three fixes this app does not have on 0.13.6:

- **Device key on the funnel denominator.** `app.first_open` / `app.session_started` were stamping a per-launch `wdev_*` device key instead of the persisted one, so the server could not group opens by device and `min_sessions` could never advance.
- **The review/questionnaire gate counted JS processes, not app-opens.** iOS suspends rather than kills, so `minSessions: 2` was unsatisfiable on a phone that is never force-quit. ⚠️ **Consequence worth stating: review prompts that were silently dormant may start firing.** That is the fix, not a regression, but it will move the numbers.
- **An unreadable permission record** is no longer read as "nothing settled", which was re-asking a permission iOS grants exactly once and shrinking the stored record.

## Gates

There is no CI in this repo, so these were run locally on the branch, in an isolated worktree with its own `node_modules`:

| Gate | Result |
|---|---|
| `yarn install` | exit 0 |
| `npx tsc --noEmit` | exit 0 |
| `yarn test --ci` | exit 0 — 8 suites passed, 71 tests passed, 0 failed |
| Installed version | `node_modules/@wireai/activation/package.json` reports `0.14.1` |
| Lockfile | `yarn.lock` resolves `@wireai/activation@0.14.1` (sha512-9zfKn53Y…) |
| `git diff --stat` vs trunk | `package.json` + `yarn.lock` only |

⚠️ This is a native app: merging does not ship anything to users. The re-pin reaches devices only in a new native build.

Base `development` was re-verified at `6a0b85d` immediately before push, unchanged.