### PR TITLE
docs(replit): .replit + replit.md + an honest Replit/Rork README section

### DIFF
--- a/.replit
+++ b/.replit
@@ -1,0 +1,24 @@
+# Replit manifest for this boilerplate.
+#
+# Replit's language auto-detection is npm-biased. This repo is yarn (yarn.lock is
+# the committed lockfile), so the Run button is pinned here instead of guessed.
+# Run does two things: install from the lockfile, then start the Expo dev server
+# (Metro) on port 8081.
+#
+# Read the "Replit and Rork" section of README.md before you press Run. The short
+# version: a Replit container gives you the editor, the Agent and Metro. It cannot
+# give you a running app. This boilerplate declares Expo config plugins and native
+# modules that Expo Go cannot load, so the QR-code path does not work here. A
+# development build (yarn ios / yarn android locally, or EAS) is the real path.
+#
+# Agent context lives in replit.md. The architecture rules it must obey live in
+# .cursor/rules/ and are pointed at from CLAUDE.md and AGENTS.md.
+
+entrypoint = "index.ts"
+modules = ["nodejs-20"]
+run = "yarn install --frozen-lockfile && yarn start"
+
+# Metro's default port. Expo prints the dev-server URL there.
+[[ports]]
+localPort = 8081
+externalPort = 80

--- a/README.md
+++ b/README.md
@@ -227,6 +227,90 @@ yarn web
 
 ---
 
+## ☁️ Replit and Rork
+
+### Import it into Replit
+
+[![Run on Replit](https://replit.com/badge/github/chohra-med/expo_boilerplate)](https://replit.com/github/chohra-med/expo_boilerplate)
+
+```
+https://replit.com/github/chohra-med/expo_boilerplate
+```
+
+That link opens Replit's GitHub importer, and it will ask you to log in first. It takes the default
+branch, which here is `development`, not `main`.
+
+What you get is Node 20, the editor, the Replit Agent, and a Run button already pinned to
+`yarn install --frozen-lockfile && yarn start`. Replit's language detection guesses npm; this repo
+ships `yarn.lock`, so `.replit` pins yarn explicitly rather than letting it guess. Agent context
+lives in `replit.md`, which points at the same `.cursor/rules/` files Claude and Cursor read.
+
+### Expo Go cannot run this app, and Replit's Expo path ends in Expo Go
+
+Worth knowing before you press Run. Replit's Expo story is "start the dev server, scan the QR code
+with Expo Go", and two things block that here.
+
+First, `app.json` declares seven Expo config plugins, and a config plugin only does something
+during a native prebuild, which Expo Go never runs. Second, the dependency list carries native
+modules Expo Go does not bundle: `@react-native-firebase/app`, `@react-native-firebase/analytics`,
+`@react-native-firebase/crashlytics`, `react-native-mmkv`, `react-native-nitro-modules`,
+`react-native-purchases` and `react-native-keyboard-controller`. Metro will start and print a QR
+code. The bundle then fails on the phone.
+
+So the honest value of a Replit container here is the editing loop: the Agent, `yarn type:check`,
+Biome and `yarn test:ci` (8 suites, 71 tests). Running the app needs a development build, either
+`yarn ios` / `yarn android` on a machine with Xcode or Android Studio, or an EAS build. A Linux
+container has neither.
+
+### If you want an Expo Go version anyway
+
+It is a trade, not a switch. The whole change is four steps:
+
+1. remove the `@react-native-firebase/app` and `@react-native-firebase/crashlytics` plugin entries from `app.json`, along with the `expo-build-properties` `useFrameworks: static` entry that only exists for the Firebase pods
+2. remove `@react-native-firebase/*`, `react-native-mmkv`, `react-native-nitro-modules`, `react-native-purchases` and `react-native-keyboard-controller` from `package.json`
+3. move redux-persist and the Wire onboarding session store from MMKV to `@react-native-async-storage/async-storage`, which is already a dependency
+4. stub the RevenueCat service and the analytics and Crashlytics transports, so the paywall screen and every existing analytics call still type-check
+
+What that costs you: crash reporting, product analytics, in-app purchases, and the fast synchronous
+store. Fine for a demo. Not fine for something you intend to put on the App Store.
+
+### Secrets
+
+Replit copies Secrets into a remix as names only. Values never travel, which is exactly the
+behavior you want on a public repo. Set your own in the Secrets pane:
+
+```
+EXPO_PUBLIC_WIREAI_API_KEY
+EXPO_PUBLIC_WIREAI_APP_ID
+EXPO_PUBLIC_WIREAI_SERVER_URL
+EXPO_PUBLIC_REVENUECAT_IOS_API_KEY
+EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY
+EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID
+```
+
+All six are optional. With none of them set the app boots anyway, onboarding renders the built-in
+static questionnaire, and the paywall degrades gracefully. Firebase is the odd one out, and it is
+not an env var at all: it wants `google-services.json` and `GoogleService-Info.plist`, two files
+that have no business in a public repo.
+
+### Rork
+
+Rork cannot import this repo, or any repo. It generates Expo apps from prompts, and its GitHub
+integration runs the other way around: you build in Rork, then Rork creates the repo for you.
+Checked on 2026-08-18 against Rork's own docs index, where "import", "template" and "github" turn
+up exactly once between them, on the "sync your project with Github" tutorial. `rork.com/templates`
+serves the homepage. There is no template format to publish, so this repo publishes none, and any
+`rork.json` you see in the wild is somebody's invention.
+
+The one real touchpoint is `rork-local` (Apache 2.0,
+[rorkai/rork-local](https://github.com/rorkai/rork-local)), a localhost UI that streams a live iOS
+simulator and drives App Store Connect publishing against an app directory you already have. It
+needs macOS, the Xcode command line tools and Node 20, so it is a laptop tool and not a Replit one.
+Its README says `npx rork-local`, but no `rork-local` package exists on the public npm registry as
+of 2026-08-18, the registry answers 404, so run it from a checkout of that repo instead.
+
+---
+
 ## 🏗️ Architecture Overview
 
 ### Feature-First Structure

--- a/replit.md
+++ b/replit.md
@@ -1,0 +1,99 @@
+# replit.md: context for the Replit Agent
+
+The Replit analogue of `CLAUDE.md` and `AGENTS.md`. Those two are the source. This file repeats
+only what an agent working inside a Replit container needs, plus the constraints that are specific
+to running this repo on Replit.
+
+## What this project is
+
+AI-first React Native + Expo boilerplate. Feature-first architecture, built so that AI coding tools
+produce consistent, predictable code instead of a new idiom every session. Lite (MIT) version of
+[AI Mobile Launcher](https://www.aimobilelauncher.com/).
+
+Stack: Expo 55, React Native 0.83.6, React 19, TypeScript strict, Redux Toolkit + RTK Query,
+Restyle, MMKV, Reanimated 4, FlashList, Biome, i18next, Zod.
+
+## Read the rules before you write code
+
+The single source of truth for architecture and conventions is `.cursor/rules/`. Those files are
+tracked in git, so they are already in your container.
+
+| Topic | File |
+|---|---|
+| Architecture, feature-first directory structure | `.cursor/rules/app_feature_first_architecture.mdc` |
+| Code standards, UI, navigation, Redux, state, testing | `.cursor/rules/app_rules.mdc` |
+| Error handling, env vars, accessibility | `.cursor/rules/best_practices.mdc` |
+| The non-negotiable principles | `constitution.md` |
+
+Reading them is not optional. Code that skips them looks plausible and still breaks the
+architecture the rest of the repo is built on.
+
+## What a Replit container can and cannot do here
+
+It can edit code, run the type-checker, run Biome, run the Jest suite, and start Metro.
+
+It cannot run the app. Replit's Expo path ends in "scan the QR code with Expo Go", and this
+boilerplate cannot load in Expo Go. `app.json` declares Expo config plugins, which only take effect
+during a native prebuild, and the dependency list carries native modules Expo Go does not bundle:
+`@react-native-firebase/app`, `@react-native-firebase/analytics`,
+`@react-native-firebase/crashlytics`, `react-native-mmkv`, `react-native-nitro-modules`,
+`react-native-purchases`, `react-native-keyboard-controller`. Metro will start. The bundle will
+then fail on the phone. Building this app needs a development build, meaning `yarn ios` or
+`yarn android` on a machine with Xcode or Android Studio, or an EAS build. A Linux container has
+neither.
+
+⛔ Do not "fix" that by ripping the native modules out. Crashlytics, RevenueCat and MMKV are
+features people use, not obstacles. The README documents the trade for anyone who wants to make it
+on purpose.
+
+## Commands
+
+| Command | What it does |
+|---|---|
+| `yarn install --frozen-lockfile` | Install from the lockfile |
+| `yarn start` | Start the Expo dev server (Metro). This is what the Run button runs |
+| `yarn type:check` | `tsc --noEmit`, strict |
+| `yarn lint:check` | Biome |
+| `yarn test:ci` | Jest with coverage |
+| `yarn validate` | type:check, lint:check and test:ci together. Run it before you call anything done |
+
+## House rules
+
+Yarn, never npm. `yarn.lock` is the committed lockfile, and an `npm install` here leaves a second
+lockfile and a different tree behind.
+
+Biome, not ESLint and not Prettier. The config is `biome.jsonc`. Do not add a competing formatter.
+
+TypeScript is strict and `any` is not an escape hatch. The signature is the contract.
+
+Every dependency needs a one-line justification. If you cannot write that line, do not add the
+package. Prefer what is already installed.
+
+Keep the diff surgical. Touch what the task requires, and leave anything else as a noted follow-up
+rather than an unrequested cleanup.
+
+Non-trivial logic gets a failing test first. Tests live next to the code they cover.
+
+This repo is public and MIT. No API key, no tenant id, no customer name, no internal URL in
+anything you write. Placeholders only.
+
+## Secrets
+
+Replit copies Secrets into a remix as names only. Values never travel, which is the behavior you
+want here. Set your own values in the Secrets pane.
+
+Every variable below is optional. With none of them set the app still boots: onboarding renders the
+built-in static questionnaire and the paywall degrades gracefully.
+
+| Name | Read by |
+|---|---|
+| `EXPO_PUBLIC_WIREAI_API_KEY` | `@wireai/activation`, turns on backend-driven onboarding |
+| `EXPO_PUBLIC_WIREAI_APP_ID` | `@wireai/activation` |
+| `EXPO_PUBLIC_WIREAI_SERVER_URL` | `@wireai/activation` |
+| `EXPO_PUBLIC_REVENUECAT_IOS_API_KEY` | the RevenueCat service |
+| `EXPO_PUBLIC_REVENUECAT_ANDROID_API_KEY` | the RevenueCat service |
+| `EXPO_PUBLIC_REVENUECAT_ENTITLEMENT_ID` | the RevenueCat service, defaults to `premium` |
+
+⛔ Never commit a value. `.gitignore` excludes `.env*` and tracks only `.env.example`. Firebase is
+the odd one out and it is not an env var at all: it needs `google-services.json` and
+`GoogleService-Info.plist`, two files that have no business in a public repo.


### PR DESCRIPTION
Makes this repo importable into Replit with a Run button that actually works, and documents what a Replit container can and cannot do with it. Docs and config only.

## What is in the diff

| File | What |
|---|---|
| `.replit` | `entrypoint = index.ts`, `modules = ["nodejs-20"]` (matches `.nvmrc`), `run = "yarn install --frozen-lockfile && yarn start"`, Metro's 8081 mapped to external 80 |
| `replit.md` | Replit Agent context, derived from `CLAUDE.md` + `AGENTS.md` instead of being a third source of truth. Points at the tracked `.cursor/rules/` files, lists the real commands, documents the six optional `EXPO_PUBLIC_*` names |
| `README.md` | New "Replit and Rork" section: import URL, the Expo Go wall, the development-build path, a four-step Expo-Go-safe recipe with its cost, Secrets rules, the Rork situation |

`app.json`, `package.json` and `yarn.lock` are untouched. No dependency added or removed. No `eas` command run.

## The Expo Go call

Replit's Expo path ends in "scan the QR code with Expo Go", and this repo cannot load in Expo Go, so the README says that rather than promising a remix-and-run that does not exist.

Two independent blockers, both enumerated in the section:

1. `app.json` declares 7 Expo config plugins, two of them `@react-native-firebase/app` and `@react-native-firebase/crashlytics`. A config plugin only takes effect during a native prebuild, which Expo Go never runs.
2. Seven dependencies ship native code Expo Go does not bundle: `@react-native-firebase/app`, `@react-native-firebase/analytics`, `@react-native-firebase/crashlytics`, `react-native-mmkv`, `react-native-nitro-modules`, `react-native-purchases`, `react-native-keyboard-controller`. (Enumerated mechanically by checking each dependency in `node_modules` for a podspec or an `android/` folder, then subtracting what Expo Go bundles.)

Metro starts, the bundle fails on the phone. So the README documents the development build (`yarn ios` / `yarn android` locally, or EAS) as the real path, and gives the exact four-step recipe for anyone who wants an Expo-Go-safe variant anyway, with what that trade costs. No branch is linked, because no Expo-Go-safe branch exists on this remote and a dead pointer in a public README is worse than no pointer.

## The Rork call

Rork has no template mechanism, so nothing here pretends otherwise and no `rork.json` was invented. Verified 2026-08-18 against `docs.rork.com/llms.txt` (68 lines, where "import", "template" and "github" appear once between them, on the "sync your project with Github" tutorial) and `rork.com/templates`, which serves the homepage. Rork's GitHub integration runs the other way: you build in Rork, Rork creates the repo.

`rork-local` (Apache 2.0, `rorkai/rork-local`) is named as the only real touchpoint, with the caveat that no `rork-local` package exists on the public npm registry as of 2026-08-18 (the registry answers 404), so `npx rork-local` is documented by them but is not a live command. It is also macOS + Xcode only, so it is not a Replit tool.

## Import URL

`https://replit.com/github/chohra-med/expo_boilerplate` (302 to `/import/github/chohra-med/expo_boilerplate` behind login).

The `https://replit.com/github.com/<owner>/<repo>` form 302s to `https://replit.com/` and does not import, so it is not used.

## Verification

Baseline on `origin/development` (`500512c`) and again after the change, same three commands, same results:

| Command | Baseline | After |
|---|---|---|
| `yarn install --frozen-lockfile` | exit 0 | exit 0 |
| `npx tsc --noEmit` | exit 0 | exit 0 |
| `yarn test --ci` | exit 0, 8 suites / 71 tests passed | exit 0, 8 suites / 71 tests passed |

`.replit` was checked programmatically, not by eye: parsed with Python `tomllib`, `entrypoint` confirmed to exist on disk, and every segment of `run` split on `&&` and resolved against `package.json` scripts (`install` recognised as a yarn builtin, `start` confirmed present). A negative control with `run = "yarn dev"` made the same check exit 1, so it fails when it should.

`git diff --cached --stat`: 3 files changed, 207 insertions, 0 deletions.