### PR TITLE
feat(wire): canon Wire integration layer + mounts (env-gated OFF)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Wire AI integration layer, env-gated OFF by default.** Copied the app-agnostic shared layer
+  from the Standard tier (source of truth) verbatim — `src/services/wire/` (the single
+  `EXPO_PUBLIC_WIREAI_*` read + derived config, the fail-closed gate-storage factory, the
+  permission-screen builder, the report-only RevenueCat → Wire purchase funnel),
+  `src/ui/providers/wire-provider.tsx` (feature flags + icon registry), and
+  `src/ui/hooks/use-wire-questionnaire-gate.ts`. Mounted per this repo's structure:
+  `WireProvider` at the app root, `<WireQuestionnaireGate />` on the home screen,
+  `permissionScreens` on the onboarding flow, a `__DEV__`-only `<WireDemoOnboarding />` in
+  settings, and `createWirePurchaseFunnel` reporting the five purchase moments on the paywall.
+  With no Wire key set (a fresh clone) every surface is inert — no crash, no network, no console
+  noise — proven by `src/services/wire/__tests__/wire-no-env-inert.test.tsx`. No new runtime
+  dependency: all imports resolve to packages already in `package.json`. The permission-screen
+  mount ships EMPTY (this template bundles no permissions module) with a documented injection
+  point. See `src/features/wire/README.md`.
+
 ### Changed
 
 - Bumped `@wireai/activation` `^0.11.0` → **`0.13.6`** and `wireai-rn` `^0.2.4` →

--- a/src/entrypoints/app.tsx
+++ b/src/entrypoints/app.tsx
@@ -15,11 +15,14 @@ import { useScreenTracking } from "#root/analytics";
 import { IS_TESTING_COACHMARK } from "#root/config/coachmarks";
 import { useAppInitializer } from "#root/entrypoints/hooks";
 import { wireLifecycleConfig } from "#root/features/onboarding/services/wire-lifecycle";
+import { wireOnboardingStorage } from "#root/features/onboarding/services/wire-onboarding-storage";
 import { RootStackNavigator } from "#root/navigation/navigators/root-stack-navigator";
 import type { RootStackParamList } from "#root/navigation/routes";
 import { coachmarkStorage } from "#root/services/storage";
+import { getWireFeaturesConfig } from "#root/services/wire";
 import { persistor, store } from "#root/store/store";
 import { ToastProvider } from "#root/ui/components/toast-provider";
+import { WireProvider } from "#root/ui/providers/wire-provider";
 import { ThemeProvider, useTheme } from "#root/ui/style/theme-provider";
 import "#root/config/i18n";
 import { AppErrorBoundary } from "#root/providers/app-error-boundary/app-error-boundary";
@@ -98,6 +101,11 @@ const AppContent: React.FC = () => {
   );
 };
 
+// Wire AI kill switches + icon registry, resolved once. With no `EXPO_PUBLIC_WIREAI_*` env
+// this is `undefined`, and `WireProvider` never fetches — every gated surface below (coachmarks,
+// showcase, questionnaire) falls back to its all-on defaults, so a keyless clone is unchanged.
+const wireFeaturesConfig = getWireFeaturesConfig(wireOnboardingStorage);
+
 const App: React.FC = () => {
   return (
     <Provider store={store}>
@@ -105,7 +113,13 @@ const App: React.FC = () => {
         <ThemeProvider>
           <ToastProvider>
             <AppErrorBoundary>
-              <AppContent />
+              {/*
+                Wire AI feature flags (outermost, so the kill switches gate every surface below)
+                + icon registry. Mounted once near the root. Inert without a Wire key.
+              */}
+              <WireProvider featuresConfig={wireFeaturesConfig}>
+                <AppContent />
+              </WireProvider>
             </AppErrorBoundary>
           </ToastProvider>
         </ThemeProvider>

--- a/src/features/home/screens/home-screen.tsx
+++ b/src/features/home/screens/home-screen.tsx
@@ -16,6 +16,7 @@ import Animated, {
 } from "react-native-reanimated";
 import { analytics, EVENTS, FEATURE_NAMES } from "#root/analytics";
 import { buildHomeTourSteps, HOME_TOUR_ID } from "#root/config/coachmarks";
+import { WireQuestionnaireGate } from "#root/features/wire";
 import type { AppTabStackParamsList } from "#root/navigation/routes";
 import { Box, Button, Card, Icon, SafeArea, Text } from "#root/ui/components";
 
@@ -252,6 +253,13 @@ const HomeScreenComponent: React.FC = () => {
           </AnimatedBox>
         </Box>
       </ScrollView>
+
+      {/*
+        Wire AI in-app feedback popup. Renders nothing until FOUR gates all open: a Wire key is
+        configured, the dashboard kill switch is on, the local rules (3 app-opens, once/version)
+        are met, and nothing is suppressing it. Inert on a keyless clone.
+      */}
+      <WireQuestionnaireGate />
     </SafeArea>
   );
 };

--- a/src/features/onboarding/screens/wire-onboarding-screen.tsx
+++ b/src/features/onboarding/screens/wire-onboarding-screen.tsx
@@ -10,6 +10,7 @@ import { FeatureShowcase } from "@wireai/activation/showcase";
 import type React from "react";
 import { useCallback, useState } from "react";
 import { analytics, EVENTS } from "#root/analytics";
+import { getWirePermissionScreens } from "#root/features/wire";
 import { logger } from "#root/services/logging";
 import { useAppDispatch } from "#root/store/store";
 import { Box } from "#root/ui/components";
@@ -129,6 +130,10 @@ export const WireOnboardingScreen: React.FC = () => {
         // present — which is why `wire-onboarding-storage.ts` rejects on failure
         // instead of pretending. Read the note there before you "harden" it.
         storage={wireOnboardingStorage}
+        // Mid-flow OS-permission priming screens. EMPTY on this Lite template (it ships no
+        // permissions module), so the flow is unchanged — inject a handler in
+        // `features/wire/config/wire-permission-screens.ts` to enable notification priming.
+        permissionScreens={getWirePermissionScreens()}
         fallbackFlow={<StaticOnboardingScreen />}
         onComplete={handleComplete}
         onSkip={handleSkip}

--- a/src/features/paywall/screens/paywall-screen.tsx
+++ b/src/features/paywall/screens/paywall-screen.tsx
@@ -4,8 +4,10 @@ import { useTranslation } from "react-i18next";
 import Purchases, { type PurchasesPackage } from "react-native-purchases";
 import { analytics, EVENTS, FEATURE_NAMES, setPlanTier } from "#root/analytics";
 import { completeOnboarding } from "#root/features/onboarding/store/onboarding-slice";
+import { wireOnboardingStorage } from "#root/features/onboarding/services/wire-onboarding-storage";
 import { logger } from "#root/services/logging";
 import { ENTITLEMENT_ID, revenueCatService } from "#root/services/revenuecat";
+import { createWirePurchaseFunnel } from "#root/services/wire";
 import { useAppDispatch } from "#root/store/store";
 import { PaywallView } from "../components/paywall-view";
 import { getPaywallConfigForVariant } from "../config/paywall-config";
@@ -36,6 +38,20 @@ const _PaywallScreen: React.FC<PaywallScreenProps> = ({ onboarding = false }) =>
   const { i18n } = useTranslation();
   const dispatch = useAppDispatch();
   const navigation = useNavigation();
+
+  // Wire AI purchase funnel — reports the five purchase moments (shown → checkout →
+  // completed / failed / restored) into the SAME event stream as onboarding, joined on the
+  // install's `device_key` via the shared onboarding storage. Report-only: it never decides
+  // entitlement (that stays the RevenueCat check below). With no Wire key it is a structural
+  // no-op that constructs nothing and touches no network.
+  const wirePurchases = useMemo(
+    () =>
+      createWirePurchaseFunnel({
+        entitlementId: ENTITLEMENT_ID,
+        storage: wireOnboardingStorage,
+      }),
+    []
+  );
 
   // No Remote Config in the Lite tier — the default "control" variant is used.
   const paywallVariant = "control";
@@ -112,6 +128,9 @@ const _PaywallScreen: React.FC<PaywallScreenProps> = ({ onboarding = false }) =>
         setSelectedPackage(convertedPackages[0]);
       }
 
+      // Wire funnel: the paywall became visible with a real offering.
+      wirePurchases.paywallShown(offering);
+
       analytics.track(EVENTS.PAYWALL_VIEW, {
         source: paywallVariant,
         packages_count: convertedPackages.length,
@@ -161,7 +180,14 @@ const _PaywallScreen: React.FC<PaywallScreenProps> = ({ onboarding = false }) =>
         throw new Error("Package not found");
       }
 
+      // Wire funnel: the user tapped buy and the store sheet is opening.
+      wirePurchases.checkoutStarted(revenueCatPackage);
+
       const purchaseResult = await Purchases.purchasePackage(revenueCatPackage);
+
+      // Wire funnel: the store returned. Reports completed vs not_entitled and syncs plan tier —
+      // it does NOT decide entitlement; the check below owns that.
+      wirePurchases.purchaseCompleted(purchaseResult.customerInfo, revenueCatPackage);
 
       if (typeof purchaseResult.customerInfo.entitlements.active[ENTITLEMENT_ID] !== "undefined") {
         analytics.track(EVENTS.PURCHASE, {
@@ -180,6 +206,9 @@ const _PaywallScreen: React.FC<PaywallScreenProps> = ({ onboarding = false }) =>
       setError(errorMessage);
       logger.error("[Paywall] Purchase failed", err as Error);
 
+      // Wire funnel: the purchase rejected. The kit separates a user cancel from a store error.
+      wirePurchases.purchaseFailed(err);
+
       analytics.track(EVENTS.PURCHASE_FAILED, {
         package_id: selectedPackage.identifier,
         source: paywallVariant,
@@ -193,7 +222,10 @@ const _PaywallScreen: React.FC<PaywallScreenProps> = ({ onboarding = false }) =>
   const handleRestore = useCallback(async () => {
     try {
       setIsLoading(true);
-      await revenueCatService.restorePurchases();
+      const restoredInfo = await revenueCatService.restorePurchases();
+
+      // Wire funnel: a restore finished. Reports the resulting tier.
+      wirePurchases.purchasesRestored(restoredInfo ?? undefined);
 
       analytics.track(EVENTS.PURCHASE_RESTORED, { source: paywallVariant });
 

--- a/src/features/settings/screens/main-settings-screen.tsx
+++ b/src/features/settings/screens/main-settings-screen.tsx
@@ -5,6 +5,7 @@ import { useCallback } from "react";
 import { useTranslation } from "react-i18next";
 import { ScrollView } from "react-native";
 import { SelectionButton } from "#root/features/settings/components/selection-button";
+import { WireDemoOnboarding } from "#root/features/wire";
 import type { SettingsStackParamList } from "#root/navigation/routes";
 import { Box, Button, Icon, SafeArea, Text } from "#root/ui/components";
 import { useSettings } from "../hooks/use-settings";
@@ -144,6 +145,18 @@ export const MainSettingsScreen: React.FC = () => {
                 buttonTypeVariant="outline"
               />
             </Box>
+
+            {/*
+              DEV-ONLY: re-run the real Wire AI onboarding flow on demand (no account, no
+              navigation side effects) to QA a change to the once-per-user funnel. The guard is
+              `__DEV__`, not an env var — `EXPO_PUBLIC_*` inlines at build time and would ship ON.
+              The component also self-guards, so it renders nothing in a production build.
+            */}
+            {__DEV__ ? (
+              <Box backgroundColor="backgroundSecondary" padding="lg" borderRadius="md">
+                <WireDemoOnboarding />
+              </Box>
+            ) : null}
           </Box>
         </Box>
       </ScrollView>

--- a/src/features/wire/README.md
+++ b/src/features/wire/README.md
@@ -1,0 +1,40 @@
+# Wire AI — per-app mounts
+
+The thin, app-specific half of the `@wireai/activation` integration. The app-agnostic half — the
+one env read, the gate-storage factory, the permission-screen builder, the purchase funnel and the
+`WireProvider` — lives in `#root/services/wire` and `#root/ui/providers/wire-provider`. This folder
+only holds the pieces that need THIS app's native modules, screens or copy.
+
+**Everything here is env-gated OFF by default.** With no `EXPO_PUBLIC_WIREAI_*` set (a fresh clone
+of this template), every surface below is inert: no crash, no network, no console noise. Add a Wire
+key to turn the same surfaces on. See `.env.example`.
+
+## Files
+
+| File | What it owns |
+|---|---|
+| `services/wire-gate-storage.ts` | Binds the shared gate-storage factory to MMKV. The sync counter the questionnaire gate reads during render. |
+| `config/wire-permission-screens.ts` | Mid-flow OS-permission priming screens. Ships EMPTY here — this template bundles no permissions module — with a documented injection point. |
+| `components/wire-questionnaire-gate.tsx` | The in-app feedback popup, fail-closed behind four gates. |
+| `components/wire-demo-onboarding.tsx` | `__DEV__`-only trigger to re-run the onboarding flow for QA. |
+
+## Where each one is mounted
+
+- **Feature flags + icon registry** — `WireProvider` in `src/entrypoints/app.tsx`, outermost of the
+  Wire surfaces so the kill switches gate everything below.
+- **Questionnaire gate** — `<WireQuestionnaireGate />` on the home screen
+  (`src/features/home/screens/home-screen.tsx`).
+- **Permission screens** — `getWirePermissionScreens()` passed to `<WireOnboarding>` in
+  `src/features/onboarding/screens/wire-onboarding-screen.tsx`.
+- **Dev QA trigger** — `<WireDemoOnboarding />` behind `__DEV__` in
+  `src/features/settings/screens/main-settings-screen.tsx`.
+- **Purchase funnel** — `createWirePurchaseFunnel(...)` in
+  `src/features/paywall/screens/paywall-screen.tsx`, reporting the five purchase moments
+  (shown → checkout → completed / failed / restored). Report-only: it never decides entitlement.
+
+## Expo Go note
+
+The gate storage here binds MMKV, matching how this repo already does synchronous storage
+(`src/services/storage/coachmark-storage.ts`). MMKV does not load under Expo Go — an Expo-Go build
+swaps the backend for an AsyncStorage mirror or the shared in-memory store
+(`createInMemoryGateStorage`), the one seam that has to change.

--- a/src/features/wire/components/wire-demo-onboarding.tsx
+++ b/src/features/wire/components/wire-demo-onboarding.tsx
@@ -1,0 +1,48 @@
+import { DemoOnboarding } from "@wireai/activation";
+import type React from "react";
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { logger } from "#root/services/logging";
+import { getWireConfig } from "#root/services/wire";
+
+/**
+ * Wire AI dev/QA trigger — runs the real onboarding flow on demand, in a modal, then closes.
+ *
+ * @description No loop, no account, no navigation side effects, so it is re-runnable infinitely
+ * with the same logged-in user. That is the whole point: the production flow is a once-per-user
+ * funnel, and QA-ing a change to it otherwise means wiping the app.
+ *
+ * ⛔ DEV BUILDS ONLY, and the guard is `__DEV__`, never an env var. `EXPO_PUBLIC_*` values are
+ * INLINED AT BUILD TIME, so an env-only gate is baked ON into whatever build was made with the
+ * var set and ships to the store. `__DEV__` is the only guard the bundler strips for production.
+ *
+ * The component returns `null` outside a dev build even though its only current mount is already
+ * behind a `__DEV__` check: this is the guard that travels with the component, so a future mount
+ * somewhere less careful cannot ship it.
+ *
+ * With no Wire env configured, `config` is `null` and the kit renders its own "not integrated
+ * yet" hint instead of the flow. Nothing crashes and nothing is fetched.
+ *
+ * @inventory
+ */
+export const WireDemoOnboarding: React.FC = () => {
+  const { t } = useTranslation();
+  const config = useMemo(() => getWireConfig(), []);
+
+  const handleComplete = useCallback(() => {
+    // The demo deliberately persists nothing. Observed only so a QA run is visible in the log.
+    logger.logEvent("wire_demo_onboarding_completed", {});
+  }, []);
+
+  if (!__DEV__) {
+    return null;
+  }
+
+  return (
+    <DemoOnboarding
+      config={config}
+      label={t("wire.demoOnboardingLabel")}
+      onComplete={handleComplete}
+    />
+  );
+};

--- a/src/features/wire/components/wire-questionnaire-gate.tsx
+++ b/src/features/wire/components/wire-questionnaire-gate.tsx
@@ -1,0 +1,103 @@
+import type {
+  QuestionnaireDefinition,
+  QuestionnaireGateEvent,
+} from "@wireai/activation/questionnaire";
+import { QuestionnaireGate } from "@wireai/activation/questionnaire";
+import type React from "react";
+import { useCallback, useMemo } from "react";
+import { useTranslation } from "react-i18next";
+import { logger } from "#root/services/logging";
+import { getWireTarget, isWireEnabled } from "#root/services/wire";
+import { useWireWhenToAskQuestionnaire } from "#root/ui/hooks";
+import { wireGateStorage } from "../services/wire-gate-storage";
+
+/**
+ * Wire AI questionnaire gate — the in-app feedback popup, server-decidable and fail-closed.
+ *
+ * @description Three questions, one per step: two skippable, then one REQUIRED, so every
+ * completed run carries at least one real answer. Answers are POSTed to the Wire server and
+ * never touch analytics props.
+ *
+ * Safe-by-default, and there are FOUR independent gates in front of it, any one of which keeps
+ * it shut:
+ *   1. no Wire env configured → `isWireEnabled()` is false and the gate is forced off, so a
+ *      fresh clone of this template never shows a popup it has no server to answer to;
+ *   2. the dashboard `questionnaire` master kill switch (read from `WireProvider`'s
+ *      `WireFeaturesProvider` automatically) — fail-open, so an unreachable control plane
+ *      leaves the local rules in charge rather than darkening the app;
+ *   3. the local rules — `minSessions` app-opens on this device, once per app version; and
+ *   4. `suppressed`, so this never lands on top of another modal. Both are centered modals, so
+ *      without this flag two could show at once.
+ *
+ * @inventory
+ */
+
+/** The gate id. Keys the kit's `wire_questionnaire_*` session / seen / last-shown storage. */
+const QUESTIONNAIRE_ID = "app_feedback";
+
+/**
+ * App-opens required before the questionnaire may fire. Asking a user to WRITE something costs
+ * more than a tap, so it should never be the first thing a new install is interrupted by.
+ */
+const MIN_SESSIONS = 3;
+
+interface WireQuestionnaireGateProps {
+  /** Hold the popup shut while something else owns the moment. */
+  suppressed?: boolean;
+}
+
+export const WireQuestionnaireGate: React.FC<WireQuestionnaireGateProps> = ({
+  suppressed = false,
+}) => {
+  const { t } = useTranslation();
+
+  // Env is read once per process by the shared config module; this is a memo read, not a parse.
+  const enabled = isWireEnabled();
+  const target = useMemo(() => getWireTarget(), []);
+
+  const questionnaire = useMemo<QuestionnaireDefinition>(
+    () => ({
+      id: QUESTIONNAIRE_ID,
+      opinion_label: t("wire.questionnaire.opinionLabel"),
+      improve_label: t("wire.questionnaire.improveLabel"),
+      suggestions_label: t("wire.questionnaire.suggestionsLabel"),
+      minSessions: MIN_SESSIONS,
+      oncePerVersion: true,
+    }),
+    [t]
+  );
+
+  const gate = useWireWhenToAskQuestionnaire({
+    config: questionnaire,
+    storage: wireGateStorage,
+    enabled,
+    suppressed,
+  });
+
+  const handleShown = useCallback(() => {
+    gate.markShown();
+  }, [gate]);
+
+  const handleResolved = useCallback(() => {
+    gate.markResolved();
+  }, [gate]);
+
+  const handleEvent = useCallback((event: QuestionnaireGateEvent) => {
+    // Gate id only. The free-text answers ride ONLY in the POST body, never in analytics.
+    logger.logEvent("wire_questionnaire_event", { name: event.name, id: event.id });
+  }, []);
+
+  if (!gate.visible) {
+    return null;
+  }
+
+  return (
+    <QuestionnaireGate
+      questionnaire={questionnaire}
+      target={target}
+      onShown={handleShown}
+      onResolved={handleResolved}
+      onEvent={handleEvent}
+    />
+  );
+};

--- a/src/features/wire/config/wire-permission-screens.ts
+++ b/src/features/wire/config/wire-permission-screens.ts
@@ -1,0 +1,56 @@
+import type { PermissionScreenConfig } from "@wireai/activation";
+import { buildWirePermissionScreens, isWireEnabled } from "#root/services/wire";
+
+/**
+ * This app's mid-flow permission priming screens for the Wire onboarding flow.
+ *
+ * @description The shared builder (`#root/services/wire`) owns the shape and the env gate; this
+ * file owns the ONE thing that cannot be shared — the native permission module. The kit imports
+ * NONE: it takes `request` / `getStatus` / `openSettings` from the host so the shared layer stays
+ * importable in every launcher tier.
+ *
+ * ── WHY THIS PUBLIC (Lite) TIER SHIPS NO HANDLERS ────────────────────────────
+ * Lite is the template a stranger clones and runs under Expo Go, so it deliberately bundles NO
+ * permissions module (`expo-notifications` is not a dependency here). With no handler injected,
+ * `buildWirePermissionScreens` returns an EMPTY array — the kit's "no permission screens" — and
+ * the onboarding flow is byte-identical to what it has always been. Nothing to prime, nothing to
+ * break.
+ *
+ * ── HOW TO TURN IT ON IN YOUR APP ────────────────────────────────────────────
+ * Install a permissions module and inject its handlers below. `request` is the ONLY function the
+ * kit calls that can open an OS dialog, and it calls it from the user's primary tap alone — never
+ * on mount. iOS grants exactly ONE native notification prompt per install; a priming screen makes
+ * sure it is spent on someone who has been told why.
+ *
+ * @example
+ * ```typescript
+ * import * as Notifications from "expo-notifications";
+ * import { Linking } from "react-native";
+ *
+ * const toStatus = (status: string, canAskAgain: boolean): WirePermissionStatus =>
+ *   status === "granted" ? "granted" : canAskAgain ? "denied" : "blocked";
+ *
+ * return buildWirePermissionScreens(
+ *   {
+ *     notifications: {
+ *       placement: "beforeEnd",
+ *       request: async () => {
+ *         const { status, canAskAgain } = await Notifications.requestPermissionsAsync();
+ *         return toStatus(status, canAskAgain);
+ *       },
+ *       getStatus: async () => {
+ *         const { status, canAskAgain } = await Notifications.getPermissionsAsync();
+ *         return toStatus(status, canAskAgain);
+ *       },
+ *       openSettings: () => void Linking.openSettings(),
+ *     },
+ *   },
+ *   isWireEnabled()
+ * );
+ * ```
+ *
+ * @returns The configured screens, or an EMPTY array when no handler is injected (the Lite
+ * default) or no Wire transport is configured — in which case the onboarding flow is unchanged.
+ */
+export const getWirePermissionScreens = (): PermissionScreenConfig[] =>
+  buildWirePermissionScreens({}, isWireEnabled());

--- a/src/features/wire/index.ts
+++ b/src/features/wire/index.ts
@@ -1,0 +1,13 @@
+/**
+ * Wire AI per-app mounts.
+ *
+ * @description The thin, NOT-synced half of the Wire integration: everything that needs this
+ * app's native modules, screens or copy. The app-agnostic half lives in `#root/services/wire`
+ * and `#root/ui/providers/wire-provider`, and is the layer shared across the launcher tiers.
+ *
+ * See the feature README for the mount map.
+ */
+export { WireDemoOnboarding } from "./components/wire-demo-onboarding";
+export { WireQuestionnaireGate } from "./components/wire-questionnaire-gate";
+export { getWirePermissionScreens } from "./config/wire-permission-screens";
+export { wireGateStorage } from "./services/wire-gate-storage";

--- a/src/features/wire/services/wire-gate-storage.ts
+++ b/src/features/wire/services/wire-gate-storage.ts
@@ -1,0 +1,35 @@
+import { createMMKV } from "react-native-mmkv";
+import { createWireGateStorage, type WireGateStorage } from "#root/services/wire";
+
+/**
+ * This app's SYNC gate storage: the shared, app-agnostic semantics bound to MMKV.
+ *
+ * @description The shared layer owns the FAILURE semantics (fail-closed reads, best-effort
+ * writes — see `src/services/wire/wire-gate-storage.ts`); this file owns only the backend
+ * choice, because the backend is the one thing the launcher tiers do not agree on. The paid
+ * tiers use MMKV (natively synchronous). The public Lite tier cannot: MMKV does not load under
+ * Expo Go, so it binds an AsyncStorage-mirroring shim to the same factory instead.
+ *
+ * One dedicated MMKV instance, kept separate from the redux-persist store and from
+ * `wire-onboarding-storage`, so gate bookkeeping can never collide with app state. What lands
+ * here is tiny and non-personal: `wire_review_*` and `wire_questionnaire_*` session counters,
+ * seen flags and last-shown timestamps.
+ *
+ * Both gates share ONE instance on purpose. They count the same thing — app-opens on this
+ * device — and the kit keys them apart by prefix, so a second instance would just be two
+ * counters disagreeing about the same fact.
+ */
+/**
+ * ⚠️ The instance id stays `wire-review-storage`, the name it had when the review gate owned
+ * this store privately. Renaming it to match the file would start a KEY ERA: every existing
+ * install's `wire_review_*` session counter and once-per-version seen flag lives under the old
+ * id, and a rename orphans them all. The blast radius would be small and fail-closed (a delayed
+ * prompt, never an ambush) but it would be a silent, avoidable data loss for zero benefit. The
+ * id is storage state; the file name is documentation. Do not "tidy" this.
+ */
+const mmkv = createMMKV({ id: "wire-review-storage" });
+
+export const wireGateStorage: WireGateStorage = createWireGateStorage({
+  read: (key: string) => mmkv.getString(key) ?? null,
+  write: (key: string, value: string) => mmkv.set(key, value),
+});

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -154,5 +154,13 @@
       "english": "English",
       "french": "Français"
     }
+  },
+  "wire": {
+    "demoOnboardingLabel": "Run Wire onboarding (dev)",
+    "questionnaire": {
+      "opinionLabel": "How's your experience so far?",
+      "improveLabel": "What could we improve?",
+      "suggestionsLabel": "Anything else you'd like to tell us?"
+    }
   }
 }

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -129,5 +129,13 @@
       "selectAll": "Sélectionner tout ce qui s'applique",
       "pleaseSpecify": "Veuillez préciser..."
     }
+  },
+  "wire": {
+    "demoOnboardingLabel": "Lancer l'onboarding Wire (dev)",
+    "questionnaire": {
+      "opinionLabel": "Comment se passe votre expérience ?",
+      "improveLabel": "Que pourrions-nous améliorer ?",
+      "suggestionsLabel": "Souhaitez-vous nous dire autre chose ?"
+    }
   }
 }

--- a/src/services/wire/README.md
+++ b/src/services/wire/README.md
@@ -1,0 +1,101 @@
+# Wire AI — shared integration layer
+
+## Overview
+
+The app-agnostic half of the `@wireai/activation` integration. Everything here imports
+`@wireai/activation` **and nothing else** — no MMKV, no `expo-constants`, no
+`expo-notifications`, no `react-native-purchases`.
+
+That constraint is not stylistic. This folder is part of the layer `launcher-sync` pushes from
+Standard (the source of truth) into the other launcher tiers, and the tiers do not ship the same
+native modules. The public Lite tier in particular has no MMKV (it must load under Expo Go), no
+notifications module and no purchase SDK. A single native import here would break it on copy.
+
+**Anything native is injected by the per-app mount** (`src/features/wire/` in this repo).
+
+## How it works
+
+### The one env read
+
+`wire-config.ts` is the only place in the app that reads `EXPO_PUBLIC_WIREAI_*`. It resolves the
+transport **once per process** and memoizes it, including the `null` case.
+
+That memo is load-bearing. The kit's `wireConfigFromEnv()` emits a dev-only `console.warn`
+naming the missing variable on **every call**, with no once-latch of its own — and
+`isOnboardingEnabled()` calls it a second time internally. Before this module, three call sites
+ran that pair on every render, so a fresh clone with no keys paid a growing pile of identical
+warnings. One read bounds it to one honest line.
+
+⚠️ Never read `process.env.EXPO_PUBLIC_*` through an alias or computed access. Expo's
+`inline-env-vars` babel plugin only inlines **static** member expressions, so an aliased read
+works in Jest (real Node env) and is `undefined` on a real device.
+
+### The files
+
+| File | What it owns |
+|---|---|
+| `wire-config.ts` | The single env read + every derived config (`getWireConfig`, `isWireEnabled`, `getWireTarget`, `getWireFeaturesConfig`). |
+| `wire-gate-storage.ts` | `createWireGateStorage(backend)` — hardens any **sync** KV backend into the store the review + questionnaire gates count with. Fail-closed reads, best-effort writes. |
+| `wire-purchase-funnel.ts` | `createWirePurchaseFunnel(...)` — the RevenueCat → Wire bridge, **report-only**, or a structural no-op when Wire is off. |
+| `wire-permission-screens.ts` | `buildWirePermissionScreens(...)` — mid-flow OS-permission priming screens, from host-injected handlers. |
+
+The React half lives next door, for the same shared-layer reason:
+`src/ui/providers/wire-provider.tsx` and `src/ui/hooks/use-wire-questionnaire-gate.ts`.
+
+### Two failure semantics that look inconsistent and are not
+
+- `wire-gate-storage.ts` **swallows** failures. It feeds a session counter behind a fail-closed
+  `minSessions` floor, so a failed read keeps the gate **shut** — the worst case is a prompt
+  that never fires.
+- `src/features/onboarding/services/wire-onboarding-storage.ts` **rejects** on failure. It feeds
+  the kit's device-key durability check, and a swallowed write there tells the kit an id was
+  persisted when it was not — which makes the kit mint a fresh device key every launch, cap the
+  server's per-device session count at 1, and inflate distinct devices at the same time.
+
+Do not "harmonize" them.
+
+## Usage
+
+```tsx
+// Root (src/entrypoints/app.tsx)
+const wireFeaturesConfig = getWireFeaturesConfig(wireOnboardingStorage);
+
+<WireProvider featuresConfig={wireFeaturesConfig}>
+  <AppContent />
+</WireProvider>
+```
+
+```ts
+// Purchase funnel (src/features/paywall/screens/paywall-screen.tsx)
+const wirePurchases = createWirePurchaseFunnel({
+  entitlementId: 'pro',
+  storage: wireOnboardingStorage,
+});
+wirePurchases.paywallShown(offering, { variant });
+```
+
+## Configuration
+
+| Variable | Required | Effect |
+|---|---|---|
+| `EXPO_PUBLIC_WIREAI_API_KEY` | yes | Tenant key. Missing → the whole integration is off. |
+| `EXPO_PUBLIC_WIREAI_SERVER_URL` | yes | Wire server base URL. Missing → the whole integration is off. |
+| `EXPO_PUBLIC_WIREAI_APP_ID` | no | Namespaces storage + the flags cache. Defaults to `"default"`. |
+
+**With none of them set, every capability degrades to a clean no-op.** That is the state a fresh
+clone of this boilerplate ships in, and it is covered by
+`src/services/wire/__tests__/wire-no-env-inert.test.tsx`.
+
+## Troubleshooting
+
+**"The review / questionnaire gate never fires."** Most likely correct: both floors are
+fail-closed and count app-opens, and an app-open is a foreground after 30+ minutes backgrounded,
+not a JS process start. Check the counter in the `wire-review-storage` MMKV instance. If the kit
+logged "the gate has no sync storage", the `storage` prop was dropped.
+
+**"Nothing reaches the server."** `getWireConfig()` is `null`. The kit prints which variable is
+missing, once, at startup in a dev build.
+
+**"A dashboard kill switch did nothing."** The flags fail **open** by design and are cached. A
+surface with no `WireFeaturesProvider` above it lazily fetches its own copy; make sure the
+provider is mounted above it.

--- a/src/services/wire/__tests__/wire-no-env-inert.test.tsx
+++ b/src/services/wire/__tests__/wire-no-env-inert.test.tsx
@@ -1,0 +1,198 @@
+/**
+ * THE proof that matters most for a boilerplate: with NO `EXPO_PUBLIC_WIREAI_*` env vars set,
+ * every Wire AI surface is INERT.
+ *
+ * This is what a stranger cloning the template experiences on their very first `yarn start`.
+ * They have no Wire key and are not going to get one before deciding whether the repo works, so
+ * "Wire is present" must cost them exactly nothing: no crash, no thrown promise, no network
+ * call, and no wall of console noise implying something is broken.
+ *
+ * ⚠️ These tests are the guard on that promise. If one goes red, do NOT relax the assertion —
+ * a Wire surface has started doing something on its own with no configuration, and that ships
+ * to every buyer AND to the public Lite template.
+ *
+ * Falsification (run this when you change the guards, to prove the tests still bite): make
+ * `getWireConfig()` return a hard-coded config instead of reading the env. Every test below
+ * except the console ones must go red.
+ */
+import { render } from "@testing-library/react-native";
+import { Text } from "react-native";
+import { WireProvider } from "#root/ui/providers/wire-provider";
+import {
+  buildWirePermissionScreens,
+  createWireGateStorage,
+  createWirePurchaseFunnel,
+  getWireConfig,
+  getWireFeaturesConfig,
+  getWireTarget,
+  isWireEnabled,
+  resetWireConfigCache,
+} from "../index";
+
+const WIRE_ENV_VARS = [
+  "EXPO_PUBLIC_WIREAI_API_KEY",
+  "EXPO_PUBLIC_WIREAI_SERVER_URL",
+  "EXPO_PUBLIC_WIREAI_APP_ID",
+] as const;
+
+/** Strip the Wire env, exactly as a fresh clone has it. */
+const clearWireEnv = (): void => {
+  for (const name of WIRE_ENV_VARS) {
+    delete process.env[name];
+  }
+};
+
+describe("Wire AI integration with NO env configured", () => {
+  let fetchSpy: jest.SpyInstance;
+  let warnSpy: jest.SpyInstance;
+  let errorSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    clearWireEnv();
+    // The env memo is a module-scope latch by design (that is the whole point — one read per
+    // process). Reset it here rather than resetting MODULES: `jest.resetModules()` would hand
+    // this file a second copy of React and break every render below.
+    resetWireConfigCache();
+
+    // Any call at all is a failure: nothing here may reach the network unconfigured.
+    fetchSpy = jest
+      .spyOn(global, "fetch")
+      .mockImplementation(() => Promise.reject(new Error("network must not be reached")));
+    warnSpy = jest.spyOn(console, "warn").mockImplementation(() => undefined);
+    errorSpy = jest.spyOn(console, "error").mockImplementation(() => undefined);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    warnSpy.mockRestore();
+    errorSpy.mockRestore();
+  });
+
+  describe("the shared config reader", () => {
+    it("resolves no config, so every surface downstream is off", () => {
+      expect(getWireConfig()).toBeNull();
+      expect(isWireEnabled()).toBe(false);
+      expect(getWireTarget()).toBeUndefined();
+      expect(getWireFeaturesConfig()).toBeUndefined();
+    });
+
+    it("reads the environment ONCE per process, however many surfaces ask", () => {
+      // Twelve reads across the four getters — the shape a real app produces when the
+      // provider, the onboarding screen, both gates and the paywall all mount.
+      for (let i = 0; i < 3; i += 1) {
+        getWireConfig();
+        isWireEnabled();
+        getWireTarget();
+        getWireFeaturesConfig();
+      }
+
+      // The kit warns (dev-only, correctly) that the key is missing, and it has NO once-latch
+      // of its own — it warns per call. The memo is what bounds that to a single notice, so a
+      // fresh clone gets one honest line instead of a growing pile of identical ones.
+      // ⚠️ If this number climbs, the memo has been broken and every Wire surface is
+      // re-parsing the env on every render.
+      expect(warnSpy.mock.calls.length).toBeLessThanOrEqual(1);
+    });
+
+    it("never logs an error", () => {
+      getWireConfig();
+      isWireEnabled();
+
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the purchase funnel", () => {
+    it("is a no-op that constructs no analytics instance and touches no network", () => {
+      const funnel = createWirePurchaseFunnel({ entitlementId: "pro" });
+
+      expect(funnel.isActive).toBe(false);
+
+      // A realistic package, matching the kit's structural RevenueCat types — NOT a `{}` cast.
+      // A fixture thinner than the real shape would let a null-deref inside the bridge pass here
+      // and blow up on a real device.
+      const pkg = {
+        identifier: "monthly",
+        packageType: "MONTHLY",
+        product: { identifier: "pro_monthly", price: 4.99, currencyCode: "EUR" },
+      };
+
+      // Every method callable with realistic arguments, none of them throwing.
+      expect(() => {
+        funnel.paywallShown(undefined, { variant: "control" });
+        funnel.checkoutStarted(pkg, { variant: "control" });
+        funnel.purchaseCompleted({ entitlements: { active: {} } }, pkg);
+        funnel.purchaseFailed(new Error("boom"), pkg);
+        funnel.purchasesRestored({ entitlements: { active: {} } });
+        funnel.syncPlanTier({ entitlements: { active: {} } });
+      }).not.toThrow();
+
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("returns void from every method, so no caller can branch on it", () => {
+      const funnel = createWirePurchaseFunnel({ entitlementId: "pro" });
+
+      // The kit's own bridge answers "is entitled now" here. Narrowing to void is what makes
+      // it impossible for a paywall to unlock on a value that means nothing when Wire is off.
+      expect(funnel.purchaseCompleted({ entitlements: { active: {} } })).toBeUndefined();
+      expect(funnel.purchasesRestored({ entitlements: { active: {} } })).toBeUndefined();
+    });
+  });
+
+  describe("permission screens", () => {
+    it("builds NO screens, so the onboarding flow is unchanged", () => {
+      const request = jest.fn();
+
+      const screens = buildWirePermissionScreens({ notifications: { request } }, false);
+
+      expect(screens).toEqual([]);
+      // The one function that can open an OS dialog was never even referenced.
+      expect(request).not.toHaveBeenCalled();
+    });
+
+    it("still builds them when a transport IS configured (the guard is the env, not a stub)", () => {
+      const request = jest.fn();
+
+      const screens = buildWirePermissionScreens({ notifications: { request } }, true);
+
+      expect(screens).toHaveLength(1);
+      expect(screens[0].permission).toBe("notifications");
+      expect(screens[0].placement).toBe("beforeEnd");
+      // Still never CALLED — only the kit's primary tap may call it.
+      expect(request).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("the gate storage", () => {
+    it("survives a throwing backend in both directions", () => {
+      const storage = createWireGateStorage({
+        read: () => {
+          throw new Error("locked");
+        },
+        write: () => {
+          throw new Error("full");
+        },
+      });
+
+      // Fail-closed on read: an unreadable counter reads as "not enough sessions yet",
+      // so the gate stays SHUT rather than ambushing a first-run user.
+      expect(storage.getItem("wire_review_x_sessions")).toBeNull();
+      expect(() => storage.setItem("wire_review_x_sessions", "3")).not.toThrow();
+    });
+  });
+
+  describe("the provider", () => {
+    it("renders its children and never fetches the kill switches", () => {
+      const { getByText } = render(
+        <WireProvider featuresConfig={getWireFeaturesConfig()}>
+          <Text>app</Text>
+        </WireProvider>
+      );
+
+      expect(getByText("app")).toBeTruthy();
+      expect(fetchSpy).not.toHaveBeenCalled();
+      expect(errorSpy).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/services/wire/index.ts
+++ b/src/services/wire/index.ts
@@ -1,0 +1,28 @@
+/**
+ * Wire AI shared integration layer.
+ *
+ * @description Everything in this folder is APP-AGNOSTIC: it imports `@wireai/activation` and
+ * nothing else. No MMKV, no expo-constants, no expo-notifications, no react-native-purchases —
+ * the public Lite tier ships none of those, and this layer is propagated to every tier by
+ * `launcher-sync`. Anything native is INJECTED by the per-app mount.
+ *
+ * See `./README.md` for the capability map and the mount checklist.
+ */
+export type { WireTarget } from "./wire-config";
+export {
+  getWireConfig,
+  getWireFeaturesConfig,
+  getWireTarget,
+  isWireEnabled,
+  resetWireConfigCache,
+  WIRE_APP_ID,
+} from "./wire-config";
+export type { WireGateStorage, WireGateStorageBackend } from "./wire-gate-storage";
+export { createInMemoryGateStorage, createWireGateStorage } from "./wire-gate-storage";
+export type {
+  BuildWirePermissionScreensOptions,
+  WirePermissionHandlers,
+} from "./wire-permission-screens";
+export { buildWirePermissionScreens } from "./wire-permission-screens";
+export type { WirePurchaseFunnel, WirePurchaseFunnelOptions } from "./wire-purchase-funnel";
+export { createWirePurchaseFunnel } from "./wire-purchase-funnel";

--- a/src/services/wire/wire-config.ts
+++ b/src/services/wire/wire-config.ts
@@ -1,0 +1,130 @@
+/**
+ * wire-config — the ONE place this app reads the `EXPO_PUBLIC_WIREAI_*` environment.
+ *
+ * @description Resolves the Wire AI transport ONCE per process and hands every Wire surface
+ * (onboarding, lifecycle events, feature flags, review gate, questionnaire gate, purchase
+ * funnel, dev QA trigger) the same answer. With NO Wire env vars set, every getter here
+ * returns `null` / `undefined` and the whole integration is inert.
+ *
+ * ## Why the memo is load-bearing, not a micro-optimisation
+ * The kit's `wireConfigFromEnv()` emits a dev-only `console.warn` NAMING the missing var on
+ * EVERY call (`config/wireConfigFromEnv.ts`, no once-latch). That warning is correct and
+ * deliberate — a silently disabled kit is the kit's quietest failure — but it is a per-call
+ * warning, and `isOnboardingEnabled()` calls `wireConfigFromEnv()` a second time internally.
+ * Before this module, three call sites each ran that pair on every render, so a fresh clone
+ * with no keys paid a growing pile of identical warnings. Reading the env once, here, bounds
+ * it to a single notice per process no matter how many Wire surfaces mount.
+ *
+ * ⚠️ Do NOT "simplify" this by re-reading the env per call, and do NOT read
+ * `process.env.EXPO_PUBLIC_*` through an alias or computed access — Expo's `inline-env-vars`
+ * babel plugin only inlines STATIC `process.env.EXPO_PUBLIC_FOO` member expressions, so an
+ * aliased read works in Jest (real Node env) and is `undefined` on a real device.
+ *
+ * ## App-agnostic on purpose
+ * This file is part of the SHARED layer that `launcher-sync` pushes from Standard into the
+ * other launcher tiers, so it imports `@wireai/activation` and nothing else. No MMKV, no
+ * expo-constants, no expo-notifications, no react-native-purchases: the Lite (public) tier
+ * ships none of those. Anything native is injected by the per-app mount.
+ *
+ * @example
+ * ```typescript
+ * import { getWireConfig, isWireEnabled } from '#root/services/wire';
+ *
+ * if (!isWireEnabled()) return <StaticOnboarding />;
+ * return <WireOnboarding config={getWireConfig()!} />;
+ * ```
+ */
+import {
+  type WireFeaturesConfig,
+  type WireOnboardingConfig,
+  type WireOnboardingStorage,
+  wireConfigFromEnv,
+} from "@wireai/activation";
+
+/**
+ * Where kit → server requests go for the gates (review / questionnaire). Structurally identical
+ * to the kit's `ReviewTarget` and `QuestionnaireTarget`, declared here so the shared layer does
+ * not have to import a subpath just for a two-field type.
+ */
+export interface WireTarget {
+  serverUrl: string;
+  apiKey: string;
+}
+
+/**
+ * The app id every Wire surface namespaces on. Read via STATIC member access so Metro inlines
+ * it (see the module note above).
+ */
+export const WIRE_APP_ID = process.env.EXPO_PUBLIC_WIREAI_APP_ID ?? "default";
+
+/**
+ * The memo. `undefined` = not read yet; `null` = read, and Wire is OFF.
+ * A module-scope latch, so the env is read (and the kit's missing-key notice printed) once.
+ */
+let cachedConfig: WireOnboardingConfig | null | undefined;
+
+/**
+ * The resolved Wire AI transport, or `null` when the env is unset.
+ *
+ * @returns The kit config when `EXPO_PUBLIC_WIREAI_API_KEY` + `EXPO_PUBLIC_WIREAI_SERVER_URL`
+ * are both set, otherwise `null`.
+ */
+export const getWireConfig = (): WireOnboardingConfig | null => {
+  if (cachedConfig === undefined) {
+    cachedConfig = wireConfigFromEnv({ appId: WIRE_APP_ID });
+  }
+  return cachedConfig;
+};
+
+/**
+ * Whether any Wire surface may do anything at all.
+ *
+ * Equivalent to the kit's `isOnboardingEnabled()` (the gate is transport presence) but reads
+ * the memo instead of re-parsing the env, so it costs nothing and prints nothing.
+ *
+ * @returns `true` only when a Wire transport is configured.
+ */
+export const isWireEnabled = (): boolean => getWireConfig() !== null;
+
+/**
+ * The server target for the review + questionnaire gates.
+ *
+ * @returns `undefined` when Wire is off — which is exactly what both gates want: with no
+ * target they never reach the network and fall back to their local, fail-closed rules.
+ */
+export const getWireTarget = (): WireTarget | undefined => {
+  const config = getWireConfig();
+  return config ? { serverUrl: config.serverUrl, apiKey: config.apiKey } : undefined;
+};
+
+/**
+ * The feature-flag (kill switch) config for `WireFeaturesProvider`.
+ *
+ * @param storage Optional host storage for the last-known-flags cache, so a cold start with a
+ * dead control plane still uses the last flags this device saw instead of the defaults.
+ * @returns `undefined` when Wire is off, which keeps the provider from ever fetching.
+ */
+export const getWireFeaturesConfig = (
+  storage?: WireOnboardingStorage
+): WireFeaturesConfig | undefined => {
+  const config = getWireConfig();
+  return config
+    ? {
+        serverUrl: config.serverUrl,
+        apiKey: config.apiKey,
+        appId: config.appId,
+        storage,
+      }
+    : undefined;
+};
+
+/**
+ * Test-only: forget the memo so a suite can re-read a mutated `process.env`.
+ *
+ * @description Never call this from app code. It exists because the memo is a module-scope
+ * latch and a test that changes the env after first read would otherwise be reading a value
+ * frozen by an earlier test.
+ */
+export const resetWireConfigCache = (): void => {
+  cachedConfig = undefined;
+};

--- a/src/services/wire/wire-gate-storage.ts
+++ b/src/services/wire/wire-gate-storage.ts
@@ -1,0 +1,101 @@
+/**
+ * wire-gate-storage — the SYNCHRONOUS bookkeeping store the kit's gates count with.
+ *
+ * @description The review gate and the questionnaire gate both need a SYNC key/value store:
+ * their "have I already shown this?" verdict has to resolve DURING render, or a popup flashes
+ * for a frame before the gate says "seen". The kit types that store structurally
+ * (`{ getItem, setItem }`), so this factory hardens ANY sync backend into it.
+ *
+ * ## Why this is a factory and not a concrete store
+ * This file is in the SHARED layer that propagates to every launcher tier, and the tiers do not
+ * agree on a sync backend: the paid tiers ship `react-native-mmkv` (natively sync), while the
+ * public Lite tier deliberately ships none of it because MMKV cannot load under Expo Go. So the
+ * BACKEND is injected by each app and only the SEMANTICS live here.
+ *
+ * ## The semantics, and why they differ from the onboarding adapter
+ * Both methods SWALLOW failures, and that is deliberate — do not "fix" it to match
+ * `wire-onboarding-storage.ts`, which rejects on purpose. The two adapters fail in opposite
+ * directions because their failure modes are opposite:
+ *   - The onboarding adapter feeds the kit's DEVICE KEY durability check. A swallowed write
+ *     there tells the kit an id was persisted when it was not, so the kit injects a fresh
+ *     device key every launch and the server's per-device session count can never exceed 1.
+ *     Failing loud there is the only honest answer.
+ *   - This store feeds a session COUNTER behind a fail-closed `minSessions` floor. A failed
+ *     read here pins the counter low, so the gate stays SHUT. That fails closed: the worst case
+ *     is a prompt that never fires, never a prompt that ambushes a first-run user.
+ *
+ * A throwing backend must therefore never propagate out of here.
+ *
+ * @example
+ * ```typescript
+ * // Per-app binding (NOT in the shared layer — MMKV is not in every tier):
+ * const mmkv = createMMKV({ id: 'wire-gate-storage' });
+ * export const wireGateStorage = createWireGateStorage({
+ *   read: (key) => mmkv.getString(key) ?? null,
+ *   write: (key, value) => mmkv.set(key, value),
+ * });
+ * ```
+ */
+
+/** The minimal SYNC backend a host binds — one read, one write, both allowed to throw. */
+export interface WireGateStorageBackend {
+  /** Read a key. Return `null`/`undefined` for a miss. May throw; the wrapper catches. */
+  read: (key: string) => string | null | undefined;
+  /** Write a key. May throw; the wrapper catches. */
+  write: (key: string, value: string) => void;
+}
+
+/**
+ * The shape the kit's gates accept for their `storage` prop (the kit's `CoachmarkStorage`).
+ * Declared structurally so the shared layer never imports the `coachmarks` subpath — that
+ * subpath statically imports `expo-blur`, which not every tier ships.
+ */
+export interface WireGateStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+}
+
+/**
+ * Harden a sync backend into the gate storage the kit expects.
+ *
+ * @param backend The app's sync key/value backend (MMKV, an AsyncStorage mirror, a Map).
+ * @returns A never-throwing `{ getItem, setItem }`. A failed read answers `null` (gate stays
+ * shut); a failed write is dropped (the gate may re-evaluate next launch).
+ */
+export const createWireGateStorage = (backend: WireGateStorageBackend): WireGateStorage => ({
+  getItem: (key: string): string | null => {
+    try {
+      return backend.read(key) ?? null;
+    } catch {
+      // Fail-closed: an unreadable counter reads as "not enough sessions yet".
+      return null;
+    }
+  },
+  setItem: (key: string, value: string): void => {
+    try {
+      backend.write(key, value);
+    } catch {
+      // Best-effort — gate bookkeeping must never break the screen it sits on.
+    }
+  },
+});
+
+/**
+ * An in-memory gate storage, for tiers or tests with no persistent sync backend.
+ *
+ * @description Real storage is strongly preferred: an in-memory counter resets on every app
+ * kill, so a `minSessions` floor takes longer to reach. It is still much better than passing
+ * NO storage at all, which makes the kit warn (dev-only) that the counter is pinned at 1 and
+ * the gate can therefore never fire.
+ *
+ * @returns A gate storage backed by a `Map` that lives for the process.
+ */
+export const createInMemoryGateStorage = (): WireGateStorage => {
+  const memory = new Map<string, string>();
+  return createWireGateStorage({
+    read: (key) => memory.get(key) ?? null,
+    write: (key, value) => {
+      memory.set(key, value);
+    },
+  });
+};

--- a/src/services/wire/wire-permission-screens.ts
+++ b/src/services/wire/wire-permission-screens.ts
@@ -1,0 +1,120 @@
+/**
+ * wire-permission-screens — build the kit's mid-flow permission priming screens, env-gated.
+ *
+ * @description iOS grants an app exactly ONE native notification prompt for its entire
+ * lifetime. Firing it on mount — the shape most apps ship — spends that single ask on a user
+ * who has not been told why. The kit's `permissionScreens` prop puts a cheap in-app rationale
+ * screen in front of it and only forwards the users who said yes; the OS dialog is reached from
+ * the primary tap and from nowhere else.
+ *
+ * ## What this file adds over calling the kit directly
+ * The kit is dependency-free here by design: it imports NO native permission module and instead
+ * takes `request` / `getStatus` / `openSettings` from the host. This builder keeps that seam
+ * intact for the SHARED layer — it imports no `expo-notifications`, because the public Lite tier
+ * does not ship it — and adds the two things every tier wants identically:
+ *   1. the env gate (no Wire transport → NO permission screens at all, so a fresh clone's
+ *      onboarding is byte-identical to what it has always been), and
+ *   2. one place to keep the placement + id conventions consistent across tiers.
+ *
+ * @example
+ * ```typescript
+ * // Per-app mount injects the native module:
+ * import * as Notifications from 'expo-notifications';
+ *
+ * const screens = buildWirePermissionScreens({
+ *   notifications: {
+ *     request: async () => {
+ *       const { status, canAskAgain } = await Notifications.requestPermissionsAsync();
+ *       return status === 'granted' ? 'granted' : canAskAgain ? 'denied' : 'blocked';
+ *     },
+ *   },
+ * });
+ * <WireOnboarding permissionScreens={screens} />
+ * ```
+ */
+import type {
+  PermissionPlacement,
+  PermissionScreenConfig,
+  WirePermissionKind,
+  WirePermissionOutcome,
+  WirePermissionStatus,
+} from "@wireai/activation";
+
+/** The native handlers ONE permission screen needs. All host-supplied; the kit imports none. */
+export interface WirePermissionHandlers {
+  /** THE ONLY function that may open an OS dialog. The kit calls it from the primary tap only. */
+  request: () => Promise<WirePermissionStatus>;
+  /** Optional NON-PROMPTING status read, so a `blocked` user is offered Settings instead of an
+   *  "Enable" button that would open nothing. */
+  getStatus?: () => Promise<WirePermissionStatus>;
+  /** Open the OS settings page. Only reachable on the `blocked` route. */
+  openSettings?: () => void | Promise<void>;
+  /** Where the screen sits in the (server-decided, variable-length) stream. Default `beforeEnd`. */
+  placement?: PermissionPlacement;
+  /** Fired once with the outcome. The seam for scheduling a local notification on a grant — the
+   *  kit deliberately schedules nothing itself. A throw here is caught and the flow continues. */
+  onResult?: (permission: WirePermissionKind, outcome: WirePermissionOutcome) => void;
+}
+
+export interface BuildWirePermissionScreensOptions {
+  /** Notification priming. Omit to ship no notification screen. */
+  notifications?: WirePermissionHandlers;
+  /** Any other permission the app wants to prime, keyed by the kit's `permission` string. */
+  extra?: Array<WirePermissionHandlers & { permission: WirePermissionKind }>;
+  /**
+   * Escape hatch for tests: build the screens even with no Wire transport configured. App code
+   * must never pass this — the env gate is the whole point.
+   */
+  force?: boolean;
+}
+
+/**
+ * Build the `permissionScreens` array for `<WireOnboarding>`.
+ *
+ * @param options The per-app native handlers.
+ * @param enabled Whether Wire is configured. Injected rather than read here so this function
+ * stays pure and the caller keeps a single env read.
+ * @returns A `PermissionScreenConfig[]`, or an EMPTY array when Wire is off or nothing was
+ * supplied. An empty array is the kit's "no permission screens" — the flow is unchanged and
+ * completion never blocks on a grant either way.
+ */
+export const buildWirePermissionScreens = (
+  options: BuildWirePermissionScreensOptions,
+  enabled: boolean
+): PermissionScreenConfig[] => {
+  if (!enabled && !options.force) {
+    return [];
+  }
+
+  const screens: PermissionScreenConfig[] = [];
+
+  if (options.notifications) {
+    screens.push(toScreen("notifications", options.notifications));
+  }
+
+  for (const entry of options.extra ?? []) {
+    screens.push(toScreen(entry.permission, entry));
+  }
+
+  return screens;
+};
+
+/**
+ * Map one set of host handlers onto the kit's screen config.
+ *
+ * @description `id` is set explicitly rather than left to the kit's positional default
+ * (`<permission>:<index>`), because that default silently re-keys the once-only record the day
+ * someone reorders the array — and a re-keyed record means a user is primed a second time.
+ */
+const toScreen = (
+  permission: WirePermissionKind,
+  handlers: WirePermissionHandlers
+): PermissionScreenConfig => ({
+  permission,
+  id: `wire-${permission}`,
+  placement: handlers.placement ?? "beforeEnd",
+  request: handlers.request,
+  getStatus: handlers.getStatus,
+  openSettings: handlers.openSettings,
+  onResult: handlers.onResult,
+});

--- a/src/services/wire/wire-purchase-funnel.ts
+++ b/src/services/wire/wire-purchase-funnel.ts
@@ -1,0 +1,140 @@
+/**
+ * wire-purchase-funnel — the purchase half of the activation funnel, env-gated and inert.
+ *
+ * @description Wraps the kit's `createRevenueCatBridge` so a paywall can report the five
+ * purchase moments (shown → checkout → completed / failed / restored) into the SAME Wire event
+ * stream as onboarding, joined on `user_context.device_key`. With no Wire env vars set, this
+ * hands back a no-op funnel: no analytics instance is constructed, no network is touched, and
+ * every method is an empty function.
+ *
+ * ## Two things this deliberately does NOT do
+ *
+ * 1. **It never imports `react-native-purchases`.** The kit types RevenueCat STRUCTURALLY on
+ *    purpose, so the bridge is adopted with zero new dependencies. That matters most for the
+ *    public Lite tier, which ships no purchase SDK at all — this file still compiles and runs
+ *    there, it just never has anything to report.
+ *
+ * 2. **It reports; it never decides.** Every method returns `void`. The kit's own
+ *    `RevenueCatBridge.purchaseCompleted()` returns "is the user entitled now", which is
+ *    tempting to branch on — and would be a live bug the day Wire is switched off, because a
+ *    no-op funnel would answer `false` and a paywall branching on it would refuse to unlock a
+ *    purchase that actually succeeded. Narrowing the surface to void makes that mistake
+ *    unrepresentable. Entitlement stays where it already is: the caller's own check against
+ *    RevenueCat's `customerInfo`.
+ *
+ * @example
+ * ```typescript
+ * const funnel = createWirePurchaseFunnel({ entitlementId: 'pro', storage });
+ * funnel.paywallShown(offering, { variant });
+ * funnel.checkoutStarted(pkg, { variant });
+ * funnel.purchaseCompleted(customerInfo, pkg, { variant });
+ * ```
+ */
+import type {
+  PurchaseProps,
+  RevenueCatCustomerInfoLike,
+  RevenueCatOfferingLike,
+  RevenueCatPackageLike,
+  WireOnboardingStorage,
+} from "@wireai/activation";
+import { createRevenueCatBridge } from "@wireai/activation";
+import { createAnalytics } from "@wireai/activation/analytics";
+import { getWireConfig } from "./wire-config";
+
+/** The report-only purchase surface. Every method is fire-and-forget and never throws. */
+export interface WirePurchaseFunnel {
+  /** `true` when a Wire transport is configured and events actually leave the device. */
+  readonly isActive: boolean;
+  /** The paywall became visible. Fires even with no offering — a paywall with nothing to sell
+   *  is exactly the failure worth seeing in the funnel. */
+  paywallShown: (offering?: RevenueCatOfferingLike, props?: PurchaseProps) => void;
+  /** The user tapped buy and the store sheet is opening. */
+  checkoutStarted: (pkg: RevenueCatPackageLike, props?: PurchaseProps) => void;
+  /** The store returned from a purchase. Reports completed vs `not_entitled` and syncs plan tier. */
+  purchaseCompleted: (
+    customerInfo: RevenueCatCustomerInfoLike | undefined,
+    pkg?: RevenueCatPackageLike,
+    props?: PurchaseProps
+  ) => void;
+  /** The purchase call rejected. The kit separates a user cancel from a real store error. */
+  purchaseFailed: (error: unknown, pkg?: RevenueCatPackageLike, props?: PurchaseProps) => void;
+  /** A restore finished. Reports the resulting tier. */
+  purchasesRestored: (
+    customerInfo: RevenueCatCustomerInfoLike | undefined,
+    props?: PurchaseProps
+  ) => void;
+  /** Write the current plan tier to the user context WITHOUT emitting an event. Call once at
+   *  launch with a `getCustomerInfo()` snapshot so returning subscribers segment correctly. */
+  syncPlanTier: (customerInfo: RevenueCatCustomerInfoLike | undefined) => void;
+}
+
+export interface WirePurchaseFunnelOptions {
+  /** The entitlement identifier that means "paid" in THIS app, exactly as configured in the
+   *  RevenueCat dashboard. Per-app: the shared layer must not guess it. */
+  entitlementId: string;
+  /** Host persistence for the event queue + the auto-minted device key. Without it the queue is
+   *  in-memory only (survives re-renders, not app kills) and the join key is per-launch. */
+  storage?: WireOnboardingStorage;
+  /** Non-PII props merged into EVERY event from this funnel. */
+  commonProps?: PurchaseProps;
+}
+
+/** The inert funnel. Structurally complete, does nothing, allocates nothing. */
+const NOOP_FUNNEL: WirePurchaseFunnel = {
+  isActive: false,
+  paywallShown: () => undefined,
+  checkoutStarted: () => undefined,
+  purchaseCompleted: () => undefined,
+  purchaseFailed: () => undefined,
+  purchasesRestored: () => undefined,
+  syncPlanTier: () => undefined,
+};
+
+/**
+ * Build the purchase funnel for this app.
+ *
+ * @param options The app's entitlement id, host storage, and any common props.
+ * @returns A live funnel when Wire is configured, otherwise the shared no-op funnel. Safe to
+ * call at module scope: with no env it constructs nothing at all.
+ */
+export const createWirePurchaseFunnel = (
+  options: WirePurchaseFunnelOptions
+): WirePurchaseFunnel => {
+  const config = getWireConfig();
+  if (!config) {
+    return NOOP_FUNNEL;
+  }
+
+  // One analytics instance for the purchase funnel. It auto-mints and persists the
+  // `device_key` that joins these events to the same install's onboarding session.
+  const analytics = createAnalytics({
+    serverUrl: config.serverUrl,
+    apiKey: config.apiKey,
+    appId: config.appId,
+    appVersion: config.appVersion,
+    storage: options.storage,
+  });
+
+  const bridge = createRevenueCatBridge({
+    analytics,
+    entitlementId: options.entitlementId,
+    commonProps: options.commonProps,
+  });
+
+  return {
+    isActive: true,
+    paywallShown: (offering, props) => bridge.paywallShown(offering, props),
+    checkoutStarted: (pkg, props) => bridge.checkoutStarted(pkg, props),
+    // Return values deliberately dropped — see the module note. The caller owns entitlement.
+    purchaseCompleted: (customerInfo, pkg, props) => {
+      bridge.purchaseCompleted(customerInfo, pkg, props);
+    },
+    purchaseFailed: (error, pkg, props) => bridge.purchaseFailed(error, pkg, props),
+    purchasesRestored: (customerInfo, props) => {
+      bridge.purchasesRestored(customerInfo, props);
+    },
+    syncPlanTier: (customerInfo) => {
+      bridge.syncPlanTier(customerInfo);
+    },
+  };
+};

--- a/src/ui/hooks/__tests__/use-wire-questionnaire-gate.test.tsx
+++ b/src/ui/hooks/__tests__/use-wire-questionnaire-gate.test.tsx
@@ -1,0 +1,77 @@
+/**
+ * The questionnaire gate's ENV guard, isolated.
+ *
+ * @description Why this file exists, and it is worth remembering: the component-level no-env
+ * test for `WireQuestionnaireGate` stayed GREEN when the env guard was deliberately broken.
+ * It was never proving the env gate at all — the jest MMKV mock returns nothing, so the
+ * app-open counter is pinned at 1, the `minSessions: 3` floor is unsatisfiable, and the gate
+ * was shut for a completely different reason. A test that passes for the wrong reason is worse
+ * than no test, because it reads like coverage.
+ *
+ * So this file gives the gate a WORKING storage and a satisfiable floor, which leaves exactly
+ * one thing standing between it and being visible: `enabled`. Now the guard is the only
+ * variable, and breaking it turns this red.
+ */
+import { renderHook } from "@testing-library/react-native";
+import { createInMemoryGateStorage } from "#root/services/wire";
+import { useWireWhenToAskQuestionnaire } from "../use-wire-questionnaire-gate";
+
+const config = { id: "test_gate", minSessions: 0, oncePerVersion: false } as const;
+
+describe("useWireWhenToAskQuestionnaire", () => {
+  it("is visible when Wire is configured and the local rules are satisfied", () => {
+    const { result } = renderHook(() =>
+      useWireWhenToAskQuestionnaire({
+        config,
+        storage: createInMemoryGateStorage(),
+        enabled: true,
+      })
+    );
+
+    // The positive control. Without this the "shut" assertions below prove nothing:
+    // a gate that can NEVER open is trivially shut with or without a guard.
+    expect(result.current.visible).toBe(true);
+  });
+
+  it("is shut when Wire is NOT configured, with everything else identical", () => {
+    const { result } = renderHook(() =>
+      useWireWhenToAskQuestionnaire({
+        config,
+        storage: createInMemoryGateStorage(),
+        enabled: false,
+      })
+    );
+
+    expect(result.current.visible).toBe(false);
+  });
+
+  it("is shut while the host suppresses it, even with Wire configured", () => {
+    const { result } = renderHook(() =>
+      useWireWhenToAskQuestionnaire({
+        config,
+        storage: createInMemoryGateStorage(),
+        enabled: true,
+        suppressed: true,
+      })
+    );
+
+    expect(result.current.visible).toBe(false);
+  });
+
+  it("does not burn the once-per-user record while it is shut", () => {
+    const storage = createInMemoryGateStorage();
+    const setItem = jest.spyOn(storage, "setItem");
+
+    const { result } = renderHook(() =>
+      useWireWhenToAskQuestionnaire({ config, storage, enabled: false })
+    );
+
+    setItem.mockClear();
+    result.current.markShown();
+    result.current.markResolved();
+
+    // A gate that was never SHOWN must not write "seen": that record is permanent, and writing
+    // it here would mean the questionnaire can never be shown once Wire IS switched on.
+    expect(setItem).not.toHaveBeenCalled();
+  });
+});

--- a/src/ui/hooks/index.ts
+++ b/src/ui/hooks/index.ts
@@ -1,2 +1,7 @@
 export type { ToastOptions, ToastType } from "./use-toast";
 export { useToast } from "./use-toast";
+export type {
+  UseWireQuestionnaireGateOptions,
+  WireQuestionnaireGateStorage,
+} from "./use-wire-questionnaire-gate";
+export { useWireWhenToAskQuestionnaire } from "./use-wire-questionnaire-gate";

--- a/src/ui/hooks/use-wire-questionnaire-gate.ts
+++ b/src/ui/hooks/use-wire-questionnaire-gate.ts
@@ -1,0 +1,106 @@
+/**
+ * useWireWhenToAskQuestionnaire — the WHEN decision for the Wire questionnaire popup.
+ *
+ * @description Wraps the kit's `useQuestionnaireGate` with the three bindings every launcher
+ * tier needs identically, so no tier re-authors them:
+ *   1. the ENV GATE — with no Wire transport the gate is forced shut, so a fresh clone never
+ *      shows a feedback popup it has no server to send answers to;
+ *   2. the sync gate STORAGE, so the app-open counter actually counts (without one the kit
+ *      warns, in dev, that the counter is pinned at 1 and the fail-closed `minSessions` floor
+ *      can therefore never be met); and
+ *   3. a host SUPPRESSION flag, so an app can keep this popup off the screen while another
+ *      modal (typically the review gate) owns the moment. The kit coordinates neither.
+ *
+ * The kit's own master kill switch still composes on top: when `questionnaire.enabled` is false
+ * on the dashboard the gate never fires, whatever the local rules or a server decision say. It
+ * reads that flag from the `WireFeaturesProvider` above automatically.
+ *
+ * @example
+ * ```typescript
+ * const gate = useWireWhenToAskQuestionnaire({
+ *   config: { id: 'app_feedback', minSessions: 3 },
+ *   storage: wireGateStorage,
+ *   enabled: isWireEnabled(),
+ *   suppressed: reviewArmed,
+ * });
+ * if (!gate.visible) return null;
+ * ```
+ */
+import type {
+  QuestionnaireDecision,
+  QuestionnaireDefinition,
+  QuestionnaireGateController,
+} from "@wireai/activation/questionnaire";
+import { useQuestionnaireGate } from "@wireai/activation/questionnaire";
+import { useMemo } from "react";
+
+/** The sync store the gate counts app-opens with. Structural, so no subpath import is needed. */
+export interface WireQuestionnaireGateStorage {
+  getItem: (key: string) => string | null;
+  setItem: (key: string, value: string) => void;
+}
+
+export interface UseWireQuestionnaireGateOptions {
+  /** The questionnaire id + local firing rules. */
+  config: QuestionnaireDefinition;
+  /** Sync gate storage. Strongly recommended: without it the counter never leaves 1. */
+  storage: WireQuestionnaireGateStorage;
+  /** Whether a Wire transport is configured. `false` forces the gate shut. */
+  enabled: boolean;
+  /** Server-provided decision, which OVERRIDES the local rules when present. */
+  decision?: QuestionnaireDecision;
+  /** Host-owned tracked app-event count, for the `minEvents` rule. */
+  events?: number;
+  /** Hold the gate shut while something else owns the screen (e.g. the review prompt). */
+  suppressed?: boolean;
+}
+
+/**
+ * Decide whether the questionnaire popup may show right now.
+ *
+ * @param options The gate config, storage, and the two host-owned gates.
+ * @returns The kit's controller. `visible` is `false` whenever Wire is off or the host
+ * suppressed it, and `markShown` / `markResolved` become no-ops in that state so a suppressed
+ * gate can never burn its once-per-user record.
+ */
+export const useWireWhenToAskQuestionnaire = ({
+  config,
+  storage,
+  enabled,
+  decision,
+  events,
+  suppressed = false,
+}: UseWireQuestionnaireGateOptions): QuestionnaireGateController => {
+  const off = !enabled || suppressed;
+
+  // Force the gate shut through the kit's OWN local rule rather than by skipping the hook:
+  // the rules of hooks forbid the conditional call, and `enabled: false` is the documented
+  // master local switch. The gate then reports `visible: false` with a real verdict, so
+  // analytics and debugging still see a decision rather than an absence.
+  const gateConfig = useMemo<QuestionnaireDefinition>(
+    () => (off ? { ...config, enabled: false } : config),
+    [off, config]
+  );
+
+  const gate = useQuestionnaireGate({
+    config: gateConfig,
+    decision: off ? undefined : decision,
+    events,
+    storage,
+  });
+
+  // A suppressed/disabled gate must not write its once-per-user seen record: the popup was
+  // never shown, and burning the record here would mean it can NEVER be shown later.
+  return useMemo<QuestionnaireGateController>(
+    () =>
+      off
+        ? {
+            visible: false,
+            decision: gate.decision,
+            markShown: () => undefined,
+            markResolved: () => undefined,
+          }
+        : gate,
+    [off, gate]
+  );
+};

--- a/src/ui/providers/wire-provider.tsx
+++ b/src/ui/providers/wire-provider.tsx
@@ -1,0 +1,63 @@
+/**
+ * Wire Provider
+ *
+ * @description The single Wire AI provider composition, mounted ONCE near the app root. It
+ * layers the kit's always-on capabilities in the order they gate each other:
+ *
+ *   WireFeaturesProvider   ← outermost: the per-module kill switches every surface below reads
+ *     └ IconRegistryProvider  ← the host's icon overrides for kit-rendered cards
+ *         └ children
+ *
+ * Both layers are inert without configuration. `WireFeaturesProvider` with NO config never
+ * fetches, and `useResolvedFeatures` falls back to the all-on defaults, so the kill switches
+ * fail OPEN — a control-plane outage can never dark the app. `IconRegistryProvider` with no
+ * registry serves one shared empty object and every icon falls through to `@expo/vector-icons`,
+ * then to no icon at all.
+ *
+ * ⚠️ Why "one fetch for the whole tree" matters: without this provider, EVERY gated surface
+ * (coachmarks / showcase / review / questionnaire) lazily fetches its own copy of the flags.
+ * Mounting it here collapses that to one request per app open.
+ *
+ * @inventory See src/ui/README.md for full inventory
+ *
+ * @example
+ * ```tsx
+ * import { WireProvider } from '#root/ui/providers/wire-provider';
+ *
+ * <WireProvider featuresConfig={getWireFeaturesConfig(storage)} icons={{ logo: <Brand /> }}>
+ *   <AppContent />
+ * </WireProvider>
+ * ```
+ */
+import {
+  IconRegistryProvider,
+  type WireFeaturesConfig,
+  WireFeaturesProvider,
+  type WireIconRegistry,
+} from "@wireai/activation";
+import React from "react";
+
+export interface WireProviderProps {
+  /**
+   * Tenant creds for the kill switches. Pass `undefined` (the value the shared config helper
+   * returns with no Wire env) and the provider NEVER fetches — flags resolve to the all-on
+   * defaults and every gated surface behaves exactly as it does with no Wire integration.
+   */
+  featuresConfig?: WireFeaturesConfig;
+  /**
+   * Host icon overrides: name → node. Lets an app ship brand artwork the kit never imports, and
+   * lets it render kit icons WITHOUT `@expo/vector-icons` installed at all.
+   */
+  icons?: WireIconRegistry;
+  children: React.ReactNode;
+}
+
+const _WireProvider: React.FC<WireProviderProps> = ({ featuresConfig, icons, children }) => {
+  return (
+    <WireFeaturesProvider config={featuresConfig}>
+      <IconRegistryProvider registry={icons}>{children}</IconRegistryProvider>
+    </WireFeaturesProvider>
+  );
+};
+
+export const WireProvider = React.memo(_WireProvider);


### PR DESCRIPTION
## What

Copies the app-agnostic **Wire AI integration layer** VERBATIM from the **Standard tier** (source of truth, `origin/development` @ `65defb4`) into this public MIT template, and mounts it per this repo's structure. Kit parity confirmed: both tiers on `@wireai/activation@0.14.1`, so the layer compiled here with zero edits (no canon defect).

## Shared layer (byte-identical to Standard)

- `src/services/wire/` — `index.ts`, `wire-config.ts` (the single `EXPO_PUBLIC_WIREAI_*` read), `wire-gate-storage.ts`, `wire-permission-screens.ts`, `wire-purchase-funnel.ts`, `README.md`, `__tests__/wire-no-env-inert.test.tsx`
- `src/ui/providers/wire-provider.tsx`
- `src/ui/hooks/use-wire-questionnaire-gate.ts` + `__tests__/`

## Per-app mounts (this repo's non-synced tree)

- **WireProvider** (feature flags + icon registry) at the app root, outermost so the kill switches gate every surface below
- `<WireQuestionnaireGate />` on the home screen
- `permissionScreens` on the onboarding flow — **EMPTY here** (this template bundles no permissions module), with a documented injection point; **no new native coupling**
- `__DEV__`-only `<WireDemoOnboarding />` in settings (guard is `__DEV__`, never an env var)
- `createWirePurchaseFunnel` reporting the five purchase moments (shown → checkout → completed / failed / restored) on the paywall — report-only, never decides entitlement
- `wire.*` i18n keys (en/fr)

## Public-template safety

- **ENV-GATED OFF by default.** With no `EXPO_PUBLIC_WIREAI_*` set (a fresh clone) every surface is inert — no crash, no network, no console noise. Proven by `wire-no-env-inert.test.tsx`.
- **No keys / tenant ids / server URLs committed** — placeholders only.
- **No new runtime dependency** — every import resolves to a package already in `package.json`; `yarn.lock` unchanged.

## Gates (local — CI on this repo does not run)

- `yarn install --frozen-lockfile` — already up-to-date
- `tsc --noEmit` — exit 0
- `jest --ci` — **10 suites / 84 tests green** (baseline 8 / 71)
- **Falsification:** forcing `getWireConfig()` to return a hard-coded config turned the no-env-inert suite **red** (3 failures), then restored byte-identical → suite green again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)