### PR TITLE
chore(wireai): re-pin @wireai/activation to 0.14.2 + correct shared-layer README claims

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@reduxjs/toolkit": "^2.11.2",
     "@shopify/flash-list": "2.0.2",
     "@shopify/restyle": "^2.4.0",
-    "@wireai/activation": "0.14.1",
+    "@wireai/activation": "0.14.2",
     "expo": "^55.0.17",
     "expo-blur": "~55.0.15",
     "expo-build-properties": "~55.0.13",

--- a/src/services/wire/README.md
+++ b/src/services/wire/README.md
@@ -8,8 +8,8 @@ The app-agnostic half of the `@wireai/activation` integration. Everything here i
 
 That constraint is not stylistic. This folder is part of the layer `launcher-sync` pushes from
 Standard (the source of truth) into the other launcher tiers, and the tiers do not ship the same
-native modules. The public Lite tier in particular has no MMKV (it must load under Expo Go), no
-notifications module and no purchase SDK. A single native import here would break it on copy.
+native modules. The public Lite tier, for instance, has no
+`expo-notifications` module. A single native import here would break a tier on copy.
 
 **Anything native is injected by the per-app mount** (`src/features/wire/` in this repo).
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,10 +2467,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@wireai/activation@0.14.1":
-  version "0.14.1"
-  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.14.1.tgz#b6e00f8216acb4f9af01039607ae7855d7008754"
-  integrity sha512-9zfKn53Yjbk/lP6hagDY1Q9o+3zEo+QfIXALn2Wq85O4JHTIB44av224hbgTInNOmENc7VQemKAaaFJOKvX3jQ==
+"@wireai/activation@0.14.2":
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.14.2.tgz#85fba0712efdedff23f3c2195189aeb18d831b4c"
+  integrity sha512-Bfu7jB8+T6z5Kai4OowvLf7frM2IikKouA77XNskH0f661j8dfLHo8vdTt3hsmaQ9tjMS0DUZEaLP+35SWsdAQ==
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.11"


### PR DESCRIPTION
## What

- Re-pins `@wireai/activation` 0.14.1 → 0.14.2 (package.json + yarn.lock, one commit). 0.14.2 makes `expo-blur` a lazily-required optional peer upstream; Lite ships expo-blur so behavior is unchanged here.
- Corrects `src/services/wire/README.md`: it claimed Lite has no MMKV and no purchase SDK, but trunk ships `react-native-mmkv ^4.3.1` and `react-native-purchases 9.6.7`. The sentence now claims only the true fact (no `expo-notifications`). The same correction lands in Standard's canon copy in its own PR.

## Gate (local — this repo's CI never runs)

- `tsc --noEmit`: exit 0
- `jest --ci`: 10/10 suites, 84/84 tests pass
- `biome check src/`: 1 pre-existing error on clean trunk (import order in `src/features/paywall/screens/paywall-screen.tsx`) — present at `0eef6db` before this change, untouched by it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)