### PR TITLE
docs(wire): correct the gate-storage comment falsified by the 0.14.2 re-pin

### DIFF
--- a/src/services/wire/wire-gate-storage.ts
+++ b/src/services/wire/wire-gate-storage.ts
@@ -47,8 +47,9 @@ export interface WireGateStorageBackend {
 
 /**
  * The shape the kit's gates accept for their `storage` prop (the kit's `CoachmarkStorage`).
- * Declared structurally so the shared layer never imports the `coachmarks` subpath — that
- * subpath statically imports `expo-blur`, which not every tier ships.
+ * Declared structurally so this app-agnostic layer never imports the `coachmarks` subpath —
+ * a UI subpath with optional native peers (`react-native-reanimated` today; `expo-blur` too
+ * before kit 0.14.2 made it lazy) that the shared layer must not drag into every tier.
  */
 export interface WireGateStorage {
   getItem: (key: string) => string | null;


### PR DESCRIPTION
One-line comment truth fix, byte-identical to Standard's canon (merged in Standard PR #12): the kit's coachmarks subpath stopped statically importing expo-blur at 0.14.2; reanimated is the static optional peer that remains. Keeps launcher-sync quiet. tsc exit 0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)