### PR TITLE
chore(wireai): re-pin @wireai/activation to 0.14.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "@reduxjs/toolkit": "^2.11.2",
     "@shopify/flash-list": "2.0.2",
     "@shopify/restyle": "^2.4.0",
-    "@wireai/activation": "0.14.2",
+    "@wireai/activation": "0.14.3",
     "expo": "^55.0.17",
     "expo-blur": "~55.0.15",
     "expo-build-properties": "~55.0.13",

--- a/yarn.lock
+++ b/yarn.lock
@@ -2467,10 +2467,10 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@wireai/activation@0.14.2":
-  version "0.14.2"
-  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.14.2.tgz#85fba0712efdedff23f3c2195189aeb18d831b4c"
-  integrity sha512-Bfu7jB8+T6z5Kai4OowvLf7frM2IikKouA77XNskH0f661j8dfLHo8vdTt3hsmaQ9tjMS0DUZEaLP+35SWsdAQ==
+"@wireai/activation@0.14.3":
+  version "0.14.3"
+  resolved "https://registry.yarnpkg.com/@wireai/activation/-/activation-0.14.3.tgz#03d6c75385e9cf5b4badf83c65a963100d486a02"
+  integrity sha512-Om0xjJIu44tYNxFsXF27pEd7ZXIzxq0K3K3z/rtR13a103ZASSM8MKRFLfbMg1OTWVH7xxjPuO+OpJzWYjz3ZA==
 
 "@xmldom/xmldom@^0.8.8":
   version "0.8.11"


### PR DESCRIPTION
Routine re-pin, queued behind Malik publishing kit 0.14.3 (npm `latest` verified = 0.14.3).

**What 0.14.3 carries for this repo:** finishes the optional-peer class 0.14.2 started — `react-native-reanimated` and the showcase pager are now guarded lazy requires, so no kit subpath force-imports an optional peer. Dependency-only diff: `package.json` + `yarn.lock`, nothing else.

**Local gates (no CI in this repo, baseline-compared):** tsc 0 errors; jest baseline unchanged.

Reaches users only in a new native build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)