### PR TITLE
docs(claude): state the trunk — `development`, and `main` does not exist

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,6 +4,35 @@ Context file for Claude Code. This acts as an entrypoint routing to our decouple
 
 ---
 
+## 🌿 Branches — the trunk is `development`, there is NO `main`
+
+⛔ **This repo's trunk is `development`.** It is the GitHub default branch and the base for every PR.
+
+⛔ **`main` does not exist here.** `gh api repos/chohra-med/expo_boilerplate/branches/main` returns **404**. Do not
+create it, do not target it, and do not assume it from habit. A PR opened against `main` cannot be
+merged because there is nothing to merge into.
+
+⚠️ **The estate is split by family — this is where the confusion comes from:**
+
+| Family | Trunk |
+|---|---|
+| The AI Mobile Launcher variants (Standard · AI · openSource), Morrow Self, Mane | **`development`** |
+| The getwireai repos (`getwireai_website`, `wireai-onboarding-server`, `wireai-activation`) | **`main`** |
+
+So "merge to main" is correct advice **for the getwireai repos and wrong for this one.** Read the
+default branch rather than carrying a habit across families:
+
+```bash
+gh repo view --json defaultBranchRef -q .defaultBranchRef.name
+```
+
+⛔ **A merge to `development` here is NOT a release.** This is a React Native / Expo app: shipping to
+users requires a **new native build**, not a merge. Never report a merged PR as shipped.
+
+⛔ **A checkout is not its trunk.** Local `development` drifts behind `origin/development` routinely.
+Base branches on `origin/development` and read trunk content with
+`git show origin/development:<path>`, never from the working tree.
+
 ## Project skill
 
 This repo ships a Claude Code skill for code generation. To use it: `/mobilelauncher <command>`


### PR DESCRIPTION
## Why

`CLAUDE.md` never stated which branch is the trunk. That gap is not theoretical — it caused a real
misdirection today: work was asked to be "merged to `main`" in these repos, and `main` **does not
exist** in any of them.

Measured, not assumed:

| repo | default branch | `main` exists? |
|---|---|---|
| `chohra-med/mane` | `development` | **No — 404** |
| `chohra-med/aimobileLauncher_standart` | `development` | **No — 404** |
| `chohra-med/ai_aimobilelauncher_mobile` | `development` | **No — 404** |
| `chohra-med/morrow_self_mobile` | `development` | **No — 404** |
| `chohra-med/expo_boilerplate` | `development` | **No — 404** |
| `chohra-med/getwireai_website` | `main` | Yes |
| `chohra-med/wireai-onboarding-server` | `main` | Yes |
| `chohra-med/wireai-activation` | `main` | Yes |

The estate is **split by family**, which is exactly why the habit travels wrong: `main` is right for
the getwireai repos and wrong here.

## What this adds

A `## 🌿 Branches` section near the top of `CLAUDE.md` recording:

- the trunk is `development`, and it is the GitHub default
- `main` does not exist — do not create or target it
- the family split, in a table
- the one command that answers it without guessing:
  `gh repo view --json defaultBranchRef -q .defaultBranchRef.name`
- **a merge here is not a release** — this is an RN/Expo app; shipping needs a new native build, so a
  merged PR must never be reported as shipped
- **a checkout is not its trunk** — base on `origin/development`, read trunk content with
  `git show origin/development:<path>`, never the working tree

Docs-only. No source file, config, or dependency is touched.